### PR TITLE
Add label and description to input definitions.

### DIFF
--- a/examples/draft-2/cat3-tool.cwl
+++ b/examples/draft-2/cat3-tool.cwl
@@ -13,6 +13,8 @@
         {
             "id": "#file1",
             "type": "File",
+            "label": "Input File",
+            "description": "The file that will be copied using 'cat'",
             "commandLineBinding": {"position": 1}
         }
     ],


### PR DESCRIPTION
This PR adds them to ``cat3-tool.cwl`` - I can pull these out using the reference implementation data structures and it doesn't seem to affect execution - but I feel like these should have be added to some schema or something - it must be more work than that :).