### PR TITLE
fix no method error on unrecognized class

### DIFF
--- a/reference/cwltool/workflow.py
+++ b/reference/cwltool/workflow.py
@@ -37,6 +37,8 @@ def makeTool(toolpath_object, docpath):
             return draft2tool.ExpressionTool(toolpath_object, docpath)
         elif toolpath_object["class"] == "Workflow":
             return Workflow(toolpath_object, docpath)
+        else:
+            raise RuntimeError("class {} not recognized".format(toolpath_object["class"]))
     else:
         raise WorkflowException("Missing 'class' field, expecting one of: Workflow, CommandLineTool, ExpressionTool, External")
 


### PR DESCRIPTION
Before `makeTool` would just return `None` on an unrecognized class, resulting in a no method error as soon as anyone else tried to use it. This just makes the problem more clear/explicit.

I was somewhat surprised that this wasn't caught by an avro validation. Looking around, I can't find a clear place where the complete tool definition is validated by the CWL avro schema. Is there a function in the library to do this in a general way (e.g. if I just wanted to load a tool definition as a python dict and validate it without actually running it)? If not what would it look like?