### PR TITLE
Fix secondary files bug

### DIFF
--- a/reference/cwltool/draft2tool.py
+++ b/reference/cwltool/draft2tool.py
@@ -117,7 +117,7 @@ class Builder(object):
                     if "secondaryFiles" in binding:
                         if "secondaryFiles" not in datum:
                             datum["secondaryFiles"] = []
-                        for sf in aslist(schema["secondaryFiles"]):
+                        for sf in aslist(binding["secondaryFiles"]):
                             if isinstance(sf, dict):
                                 sfpath = expression.do_eval(sf, self.job, self.requirements, self.docpath, datum["path"])
                             else:

--- a/reference/cwltool/draft2tool.py
+++ b/reference/cwltool/draft2tool.py
@@ -72,7 +72,7 @@ class Builder(object):
                     schema = copy.deepcopy(schema)
                     schema["type"] = t
                     return self.bind_input(schema, datum, lead_pos=lead_pos, tail_pos=tail_pos)
-            raise ValidationException("'%s' is not a valid union %s" % (datum, schema["type"]))
+            raise validate.ValidationException("'%s' is not a valid union %s" % (datum, schema["type"]))
         elif isinstance(schema["type"], dict):
             st = copy.deepcopy(schema["type"])
             if binding and "inputBinding" not in st and "itemSeparator" not in binding and st["type"] in ("array", "map"):


### PR DESCRIPTION
This fixes a bug in using `secondaryFiles`, `schema` was being used to get the list of secondaryFiles to use rather than `binding`. There probably should be a regression test for this but I don't know how to add one :/ I also noticed an unqualified reference to `ValidationException`, so I fixed that while I was at it.