### PR TITLE
Use pip instead of easy_install

### DIFF
--- a/conformance/run_test.sh
+++ b/conformance/run_test.sh
@@ -4,7 +4,7 @@ read -rd "\000" helpmessage <<EOF
 $(basename $0): Run common workflow tool description language conformance tests.
 
 Syntax:
-        $(basename $0) [CWLTOOL=/path/to/cwltool] [RABIX=/path/to/rabix]
+        $(basename $0) [CWLTOOL=/path/to/cwltool] [RABIX=/path/to/rabix] [ARVADOS=/path/to/rabix]
 
 Options:
 EOF
@@ -49,7 +49,7 @@ runtest() {
 }
 
 # Add your tool test here.
-for t in "$CWLTOOL/cwltool/main.py" "$RABIX/rabix/cliche/main.py" ; do
+for t in "$CWLTOOL/cwltool/main.py" "$RABIX/rabix/cliche/main.py" "$ARVADOS/sdk/python/bin/cwl-runner" ; do
     if [[ -x "$t" ]]; then
         runtest "$t"
     fi

--- a/reference/README.rst
+++ b/reference/README.rst
@@ -22,10 +22,10 @@ Install
 From source::
 
   git clone https://github.com/common-workflow-language/common-workflow-language.git
-  cd common-workflow-language/reference && easy_install .
+  cd common-workflow-language/reference && pip install .
   cd cwl-runner && pip install .
 
-With pip (will install "cwltool" package as well)::
+Or installing the official package from PyPi (it will install "cwltool" package as well)::
 
   pip install cwl-runner
 

--- a/reference/README.rst
+++ b/reference/README.rst
@@ -22,8 +22,8 @@ Install
 From source::
 
   git clone https://github.com/common-workflow-language/common-workflow-language.git
-  cd common-workflow-language/reference && pip setup.py install
-  cd cwl-runner && pip setup.py install
+  cd common-workflow-language/reference && python setup.py install
+  cd cwl-runner && python setup.py install
 
 Or installing the official package from PyPi (it will install "cwltool" package as well)::
 

--- a/reference/README.rst
+++ b/reference/README.rst
@@ -23,7 +23,7 @@ From source::
 
   git clone https://github.com/common-workflow-language/common-workflow-language.git
   cd common-workflow-language/reference && easy_install .
-  cd cwl-runner && easy_install .
+  cd cwl-runner && pip install .
 
 With pip (will install "cwltool" package as well)::
 

--- a/reference/README.rst
+++ b/reference/README.rst
@@ -22,8 +22,8 @@ Install
 From source::
 
   git clone https://github.com/common-workflow-language/common-workflow-language.git
-  cd common-workflow-language/reference && pip install .
-  cd cwl-runner && pip install .
+  cd common-workflow-language/reference && pip setup.py install
+  cd cwl-runner && pip setup.py install
 
 Or installing the official package from PyPi (it will install "cwltool" package as well)::
 

--- a/reference/cwltool/expression.py
+++ b/reference/cwltool/expression.py
@@ -65,7 +65,7 @@ def exeval(ex, jobinput, requirements, outdir, tmpdir, context, pull_image):
 
             (stdoutdata, stderrdata) = sp.communicate(json.dumps(inp) + "\n\n")
             if sp.returncode != 0:
-                raise WorkflowException("Expression engine returned non-zero exit code.")
+                raise WorkflowException("Expression engine returned non-zero exit code on evaluation of\n%s" % json.dumps(inp, indent=4))
 
             return json.loads(stdoutdata)
 

--- a/reference/cwltool/job.py
+++ b/reference/cwltool/job.py
@@ -14,7 +14,7 @@ import shutil
 _logger = logging.getLogger("cwltool")
 
 class CommandLineJob(object):
-    def run(self, dry_run=False, pull_image=True, rm_container=True, rm_tmpdir=True):
+    def run(self, dry_run=False, pull_image=True, rm_container=True, rm_tmpdir=True, **kwargs):
 
         if not os.path.exists(self.outdir):
             os.makedirs(self.outdir)
@@ -31,7 +31,7 @@ class CommandLineJob(object):
             if not os.path.exists(self.pathmapper.mapper(f)[0]):
                 raise WorkflowException("Required input file %s not found" % self.pathmapper.mapper(f)[0])
 
-        if docker_req:
+        if docker_req and kwargs.get("use_container") is not False:
             img_id = docker.get_from_requirements(docker_req, docker_is_req, pull_image)
             runtime = ["docker", "run", "-i"]
             for d in self.pathmapper.dirs:

--- a/reference/cwltool/job.py
+++ b/reference/cwltool/job.py
@@ -77,7 +77,7 @@ class CommandLineJob(object):
                     f.write(self.generatefiles[t])
 
         if self.stdin:
-            stdin = open(self.stdin, "rb")
+            stdin = open(self.pathmapper.mapper(self.stdin)[0], "rb")
         else:
             stdin = subprocess.PIPE
 
@@ -108,8 +108,6 @@ class CommandLineJob(object):
         if stdout is not sys.stderr:
             stdout.close()
 
-        outputs = self.collect_outputs(self.outdir)
-
         if self.successCodes and rcode in self.successCodes:
             processStatus = "success"
         elif self.temporaryFailCodes and rcode in self.temporaryFailCodes:
@@ -119,6 +117,13 @@ class CommandLineJob(object):
         elif rcode == 0:
             processStatus = "success"
         else:
+            processStatus = "permanentFail"
+
+        try:
+            outputs = {}
+            outputs = self.collect_outputs(self.outdir)
+        except Exception as e:
+            logger.warn(str(e))
             processStatus = "permanentFail"
 
         self.output_callback(outputs, processStatus)

--- a/reference/cwltool/main.py
+++ b/reference/cwltool/main.py
@@ -86,7 +86,7 @@ def arg_parser():
 
     return parser
 
-def single_job_executor(t, job_order, input_basedir, **kwargs):
+def single_job_executor(t, job_order, input_basedir, args, **kwargs):
     final_output = []
 
     def output_callback(out, processStatus):
@@ -237,7 +237,7 @@ def main(args=None, executor=single_job_executor, makeTool=workflow.defaultMakeT
 
     try:
         out = executor(t, loader.resolve_ref(args.job_order),
-                       input_basedir,
+                       input_basedir, args,
                        conformance_test=args.conformance_test,
                        dry_run=args.dry_run,
                        outdir=args.outdir,

--- a/reference/cwltool/main.py
+++ b/reference/cwltool/main.py
@@ -125,7 +125,7 @@ def single_job_executor(t, job_order, input_basedir, args, **kwargs):
             if r:
                 r.run(**kwargs)
             else:
-                raise workflow.WorkflowException("Workflow deadlocked.")
+                raise workflow.WorkflowException("Workflow cannot make any more progress.")
 
         return final_output[0]
 

--- a/reference/cwltool/main.py
+++ b/reference/cwltool/main.py
@@ -114,7 +114,7 @@ def single_job_executor(t, job_order, input_basedir, **kwargs):
         job = jobiter.next()
         a = {"args": job.command_line}
         if job.stdin:
-            a["stdin"] = job.stdin
+            a["stdin"] = job.pathmapper.mapper(job.stdin)[1]
         if job.stdout:
             a["stdout"] = job.stdout
         if job.generatefiles:

--- a/reference/cwltool/workflow.py
+++ b/reference/cwltool/workflow.py
@@ -60,7 +60,9 @@ class Workflow(Process):
                 if i["id"] in jobout:
                     self.state[i["id"]] = WorkflowStateItem(i, jobout[i["id"]])
                 else:
-                    raise WorkflowException("Output is missing expected field %s" % i["id"])
+                    _logger.error("Output is missing expected field %s" % i["id"])
+                    processStatus = "permanentFail"
+
         if processStatus != "success":
             if self.processStatus != "permanentFail":
                 self.processStatus = processStatus
@@ -222,7 +224,7 @@ class Workflow(Process):
         actual_jobs = []
 
         completed = 0
-        while completed < len(self.steps):
+        while completed < len(self.steps) and self.processStatus == "success":
             made_progress = False
             completed = 0
             for step in self.steps:

--- a/reference/cwltool/workflow.py
+++ b/reference/cwltool/workflow.py
@@ -227,7 +227,7 @@ class Workflow(Process):
                         if newjob:
                             made_progress = True
                             actual_jobs.append(newjob)
-                            yield newjob
+                        yield newjob
             if not made_progress and completed < len(self.steps):
                 yield None
 
@@ -441,7 +441,8 @@ def flat_crossproduct_scatter(process, joborder, basedir, scatter_keys, output_c
             put += 1
         else:
             for j in flat_crossproduct_scatter(process, jo, basedir, scatter_keys[1:], rc, put, **kwargs):
-                put += 1
+                if j:
+                    put += 1
                 yield j
 
     if startindex == 0 and not isinstance(output_callback, ReceiveScatterOutput):

--- a/reference/cwltool/workflow.py
+++ b/reference/cwltool/workflow.py
@@ -159,6 +159,9 @@ class Workflow(Process):
         if inputobj is None:
             return
 
+        if step.submitted:
+            return
+
         _logger.info("Creating job with input: %s", pprint.pformat(inputobj))
 
         callback = functools.partial(self.receive_output, step, outputparms)
@@ -178,6 +181,8 @@ class Workflow(Process):
                 jobs = flat_crossproduct_scatter(step, inputobj, basedir, scatter, callback, 0, **kwargs)
         else:
             jobs = step.job(inputobj, basedir, callback, **kwargs)
+
+        step.submitted = True
 
         for j in jobs:
             yield j
@@ -205,6 +210,7 @@ class Workflow(Process):
         for s in self.steps:
             for out in s.tool["outputs"]:
                 self.state[out["id"]] = None
+            s.submitted = False
             s.completed = False
 
         if "outdir" in kwargs:

--- a/schemas/draft-2/cwl-avro.yml
+++ b/schemas/draft-2/cwl-avro.yml
@@ -1281,10 +1281,17 @@
     The initial current working directory when executing the tool must be the
     designated output directory.
 
+    When executing the tool, the child process must not inherit environment
+    variables from the parent process.  The tool must execute in a new, empty
+    environment, containing only environment variables defined by
+    [EnvVarRequirement](#envvarrequirement), the default environment of the
+    Docker container specified in [DockerRequirement](#dockerrequirement) (if
+    applicable), and `TMPDIR`.
+
     The `TMPDIR` environment variable must be set in the runtime environment to
     the **designated temporary directory**.  Any files written to the
-    designated temporary directory may be deleted by the workflow
-    platform when the tool invocation is complete.
+    designated temporary directory may be deleted by the workflow platform when
+    the tool invocation is complete.
 
     An implementation may forbid the tool from writing to any location in the
     runtime environment file system other than the designated temporary

--- a/schemas/draft-2/cwl-avro.yml
+++ b/schemas/draft-2/cwl-avro.yml
@@ -758,10 +758,12 @@
         - "null"
         - Datatype
         - Schema
+        - string
         - type: array
           items:
             - Datatype
             - Schema
+            - string
       jsonldPredicate:
         "@id": "avro:type"
         "@type": "@vocab"


### PR DESCRIPTION
I had a wacky error otherwise, isn't `easy_install` too bizantine for today's python standards?:

```
$ easy_install
/Users/romanvg/anaconda/lib/python2.7/site-packages/setuptools-14.3-py2.7.egg/pkg_resources/
__init__.py:2512: PEP440Warning: 'llvmlite (0.2.2-1-gbcb15be)' is being parsed as a legacy, 
non PEP 440, version. You may find odd behavior and sort order. In particular it will be 
sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.
error: No urls, filenames, or requirements specified (see --help)
```