### PR TITLE
Usability fixes encountered during testing

### DIFF
--- a/reference/cwltool/docker.py
+++ b/reference/cwltool/docker.py
@@ -66,6 +66,9 @@ def get_image(dockerRequirement, pull_image, dry_run=False):
                 if rcode != 0:
                     raise Exception("Docker load returned non-zero exit status %i" % (rcode))
                 found = True
+        elif dockerRequirement.get("dockerImageId"):
+            raise ValueError("Docker image %s not found locally and no mechanism to pull in DockerRequirement: %s"
+                             % (dockerRequirement["dockerImageId"], dockerRequirement))
 
     return found
 

--- a/reference/cwltool/job.py
+++ b/reference/cwltool/job.py
@@ -70,6 +70,9 @@ class CommandLineJob(object):
             if not os.path.exists(self.tmpdir):
                 os.makedirs(self.tmpdir)
             env["TMPDIR"] = self.tmpdir
+            for key, value in os.environ.items():
+                if key not in env:
+                    env[key] = value
 
         stdin = None
         stdout = None

--- a/reference/cwltool/workflow.py
+++ b/reference/cwltool/workflow.py
@@ -284,8 +284,9 @@ class Workflow(Process):
 
             for a in actual_jobs:
                 if a.outdir:
-                    _logger.info("Removing intermediate output directory %s", a.outdir)
-                    shutil.rmtree(a.outdir, True)
+                    if kwargs.get("rm_tmpdir", True):
+                        _logger.info("Removing intermediate output directory %s", a.outdir)
+                        shutil.rmtree(a.outdir, True)
 
         output_callback(wo, self.processStatus)
 


### PR DESCRIPTION
- Report a useful error message for docker if we're missing an image and
  don't have a way to retrieve it.
- When running locally, pass environmental variables along to the
  subprocess run. This keeps local PATHs and friends working.
- Avoid removing temporary directories if '--leave-tmpdir' is set.