### PR TITLE
Support retrieving docker instances via 'docker import'

### DIFF
--- a/reference/cwltool/docker.py
+++ b/reference/cwltool/docker.py
@@ -66,6 +66,11 @@ def get_image(dockerRequirement, pull_image, dry_run=False):
                 if rcode != 0:
                     raise Exception("Docker load returned non-zero exit status %i" % (rcode))
                 found = True
+        elif "dockerImport" in dockerRequirement:
+            cmd = ["docker", "import", dockerRequirement["dockerImport"], dockerRequirement["dockerImageId"]]
+            _logger.info(str(cmd))
+            if not dry_run:
+                subprocess.check_call(cmd, stdout=sys.stderr)
 
     return found
 

--- a/schemas/draft-2/cwl-avro.yml
+++ b/schemas/draft-2/cwl-avro.yml
@@ -1779,7 +1779,7 @@
     container.
 
     The platform must first acquire or install the correct Docker image as
-    specified by `dockerPull`, `dockerLoad` or `dockerFile`.
+    specified by `dockerPull`, 'dockerImport', `dockerLoad` or `dockerFile`.
 
     The platform must execute the tool in the container using `docker run` with
     the appropriate Docker image and tool command line.
@@ -1812,6 +1812,9 @@
     - name: dockerFile
       type: ["null", "string"]
       doc: "Supply the contents of a Dockerfile which will be built using `docker build`."
+    - name: dockerImport
+      type: ["null", "string"]
+      doc: "Provide HTTP URL to download and gunzip a Docker images using `docker import."
     - name: dockerImageId
       type: ["null", "string"]
       doc: |


### PR DESCRIPTION
bcbio stores its container as a gzipped download via S3 because it's too big for the docker index. This PR allows pulling in instances similar to docker pull, but via docker import.