### PR TITLE
Fixes the printing of command_line arguments

### DIFF
--- a/reference/cwltool/job.py
+++ b/reference/cwltool/job.py
@@ -11,8 +11,12 @@ import docker
 from process import WorkflowException, get_feature
 import shutil
 import stat
+import re
+import shellescape
 
 _logger = logging.getLogger("cwltool")
+
+needs_shell_quoting = re.compile(r"""(^$|[\s|&;()<>\'"$@])""").search
 
 def deref_links(outputs):
     if isinstance(outputs, dict):
@@ -76,7 +80,7 @@ class CommandLineJob(object):
 
         _logger.info("outdir is %s", self.outdir)
         _logger.info("%s%s%s",
-                     " ".join(runtime + self.command_line),
+                     " ".join(runtime + [shellescape.quote(arg) if needs_shell_quoting(arg) else arg for arg in self.command_line]),
                      ' < %s' % (self.stdin) if self.stdin else '',
                      ' > %s' % os.path.join(self.outdir, self.stdout) if self.stdout else '')
 

--- a/reference/setup.py
+++ b/reference/setup.py
@@ -33,7 +33,8 @@ setup(name='cwltool',
           'avro',
           'rdflib >= 4.2.0',
           'rdflib-jsonld >= 0.3.0',
-          'mistune'
+          'mistune',
+          'shellescape'
         ],
       test_suite='tests',
       tests_require=[],


### PR DESCRIPTION
Changes the printing of command_line arguments
with --verbose / log.INFO such that when arguments
need shell quoting, they are printed using quoting
such that they should be able to be copy-and-pasted
into a shell for testing.

Adds additional an additional dependency (included in setup.py `install_requires`) on the 'shellescape' module.

Fixes #92