### PR TITLE
Use tmp_outdir_prefix when setting WorkflowJob outdir

### DIFF
--- a/reference/cwltool/workflow.py
+++ b/reference/cwltool/workflow.py
@@ -129,7 +129,11 @@ class WorkflowJob(object):
         self.id = workflow.tool["id"]
         if "outdir" in kwargs:
             self.outdir = kwargs["outdir"]
+        elif "tmp_outdir_prefix" in kwargs:
+            tmp_outdir_prefix = kwargs.get("tmp_outdir_prefix")
+            self.outdir = tempfile.mkdtemp(prefix=tmp_outdir_prefix)
         else:
+            # tmp_outdir_prefix defaults to tmp, so this is unlikely to be used
             self.outdir = tempfile.mkdtemp()
 
         _logger.debug("[workflow %s] initialized from %s", id(self), self.tool["id"])

--- a/reference/cwltool/workflow.py
+++ b/reference/cwltool/workflow.py
@@ -130,8 +130,7 @@ class WorkflowJob(object):
         if "outdir" in kwargs:
             self.outdir = kwargs["outdir"]
         elif "tmp_outdir_prefix" in kwargs:
-            tmp_outdir_prefix = kwargs.get("tmp_outdir_prefix")
-            self.outdir = tempfile.mkdtemp(prefix=tmp_outdir_prefix)
+            self.outdir = tempfile.mkdtemp(prefix=kwargs["tmp_outdir_prefix"])
         else:
             # tmp_outdir_prefix defaults to tmp, so this is unlikely to be used
             self.outdir = tempfile.mkdtemp()


### PR DESCRIPTION
When a WorkflowJob is instantiated, it now uses the tmp_outdir_prefix for the outdir before resorting to tempfile.mkdtemp()

This fixes the issue where subworkflows are unable to access files from other subworkflows when the docker host can only access volumes within user-supplied prefixes.

Fixes #108