### PR TITLE
cwl-avro.yml - added deprectation to terminology

### DIFF
--- a/schemas/draft-3/cwl-avro.yml
+++ b/schemas/draft-3/cwl-avro.yml
@@ -97,6 +97,9 @@
 
     **must**: Conforming CWL documents and CWL implementations are required to behave
     as described; otherwise they are in error.
+    
+    **deprecation**: Conforming CWL documents and CWL implementations are permitted but
+    no longer appreciated to behave as described.
 
     **error**: A violation of the rules of this specification; results are
     undefined. Conforming implementations may detect and report an error and may


### PR DESCRIPTION
Felt that if something is prepared to get in (**may**) then something shall also be prepared to get out again - the deprecation. 

Sidenote: I had felt that this paragraph mixes the properties of a schema too much with properties of an instance of that schema. Please indicate if you want me to patch that.