### PR TITLE
Fix call to undefined function when running docker_uid.py as script

### DIFF
--- a/reference/cwltool/docker_uid.py
+++ b/reference/cwltool/docker_uid.py
@@ -109,4 +109,4 @@ def docker_machine_uid():
 
 
 if __name__ == '__main__':
-    print get_docker_vm_uid()
+    print docker_vm_uid()


### PR DESCRIPTION
The function referenced in the `__main__` section of docker_uid.py referenced a function that doesn't exist.