### PR TITLE
Add option to preserve environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,4 @@ and send a pull request!
 * Brad Chapman <bchapman@hsph.harvard.edu>
 * Josh Randall <joshua.randall@sanger.ac.uk>
 * Andrey Kartashov <porter@porter.st>
+* Dan Leehr <dan.leehr@duke.edu>

--- a/reference/cwltool/job.py
+++ b/reference/cwltool/job.py
@@ -82,9 +82,10 @@ class CommandLineJob(object):
             if not os.path.exists(self.tmpdir):
                 os.makedirs(self.tmpdir)
             env["TMPDIR"] = self.tmpdir
-            if kwargs['preserve_environment']:
+            vars_to_preserve = kwargs.get("preserve_environment")
+            if vars_to_preserve is not None:
                 for key, value in os.environ.items():
-                    if key not in env:
+                    if key in vars_to_preserve and key not in env:
                         env[key] = value
 
         stdin = None

--- a/reference/cwltool/job.py
+++ b/reference/cwltool/job.py
@@ -82,6 +82,10 @@ class CommandLineJob(object):
             if not os.path.exists(self.tmpdir):
                 os.makedirs(self.tmpdir)
             env["TMPDIR"] = self.tmpdir
+            if kwargs['preserve_environment']:
+                for key, value in os.environ.items():
+                    if key not in env:
+                        env[key] = value
 
         stdin = None
         stdout = None

--- a/reference/cwltool/main.py
+++ b/reference/cwltool/main.py
@@ -34,6 +34,10 @@ def arg_parser():
                         help="Do not execute jobs in a Docker container, even when specified by the CommandLineTool",
                         dest="use_container")
 
+    parser.add_argument("--preserve-environment", action="store_true", default=False,
+                        help="Preserve environment variables when running CommandLineTools",
+                        dest="preserve_environment")
+
     exgroup = parser.add_mutually_exclusive_group()
     exgroup.add_argument("--rm-container", action="store_true", default=True,
                         help="Delete Docker container used by jobs after they exit (default)",
@@ -400,6 +404,7 @@ def main(args=None, executor=single_job_executor, makeTool=workflow.defaultMakeT
                        outdir=args.outdir,
                        tmp_outdir_prefix=args.tmp_outdir_prefix,
                        use_container=args.use_container,
+                       preserve_environment=args.preserve_environment,
                        pull_image=args.enable_pull,
                        rm_container=args.rm_container,
                        tmpdir_prefix=args.tmpdir_prefix,

--- a/reference/cwltool/main.py
+++ b/reference/cwltool/main.py
@@ -34,8 +34,9 @@ def arg_parser():
                         help="Do not execute jobs in a Docker container, even when specified by the CommandLineTool",
                         dest="use_container")
 
-    parser.add_argument("--preserve-environment", action="store_true", default=False,
-                        help="Preserve environment variables when running CommandLineTools",
+    parser.add_argument("--preserve-environment", type=str, nargs='+',
+                        help="Preserve specified environment variables when running CommandLineTools",
+                        metavar=("VAR1","VAR2"),
                         dest="preserve_environment")
 
     exgroup = parser.add_mutually_exclusive_group()


### PR DESCRIPTION
Adds an argument `--preserve-environment` to **cwltool**, allowing the user to specify environment variables (e.g. PATH) that are passed along to the CommandLineTools when containers are not used.

Usage:

`cwltool --preserve-environment PATH --no-container workflow.cwl job.json`

Fixes #103 