### PR TITLE
If Mac, use greadlink

### DIFF
--- a/CONFORMANCE_TESTS.md
+++ b/CONFORMANCE_TESTS.md
@@ -53,4 +53,7 @@ All tool tests succeeded
 ```
 
 _NOTE_: For running on OSX systems, you'll need to install coreutils via brew. This will add to your
-system some needed GNU-like tools. 
+system some needed GNU-like tools like `greadlink`.
+
+1. If you haven't already, install [brew](http://brew.sh/) package manager in your mac
+2. Run `brew install coreutils`

--- a/CONFORMANCE_TESTS.md
+++ b/CONFORMANCE_TESTS.md
@@ -14,7 +14,7 @@ Test [1/1]
 All tests passed
 ```
 
-The cwltool relies on node.js. To install on ubuntu, 
+The cwltool relies on node.js. To install on ubuntu,
 
 ```
 $ sudo apt-get install nodejs npm
@@ -51,3 +51,6 @@ All tests passed
 
 All tool tests succeeded
 ```
+
+_NOTE_: For running on OSX systems, you'll need to install coreutils via brew. This will add to your
+system some needed GNU-like tools. 

--- a/run_test.sh
+++ b/run_test.sh
@@ -13,6 +13,7 @@ EOF
 DRAFT=draft-2
 TEST_N=""
 RUNNER=cwl-runner
+PLATFORM=`uname -s`
 
 while [[ -n "$1" ]]
 do
@@ -60,7 +61,11 @@ runtest() {
     checkexit
 }
 
-runtest "$(readlink -f $runner)"
+if [[ $PLATFORM == "Linux" ]]; then
+    runtest "$(readlink -f $runner)"
+else
+    runtest "$(greadlink -f $runner)"
+fi
 
 # Final reporting
 


### PR DESCRIPTION
Fixes an issue where `run_tests.sh` fails due to a different behaviour of `readlink` in OSX systems. Reference #79 