### PR TITLE
finish restoring allowable types for parameters

### DIFF
--- a/draft-4/CommandLineTool.yml
+++ b/draft-4/CommandLineTool.yml
@@ -424,7 +424,8 @@ $graph:
   symbols: [ "cwl:stdout" ]
   docParent: "#CommandOutputParameter"
   doc: |
-    Only valid as a `type` for an output.
+    Only valid as a `type` for a `CommandLineTool` output with no
+    `outputBinding` set.
 
     The following
     ```
@@ -453,7 +454,8 @@ $graph:
   symbols: [ "cwl:stderr" ]
   docParent: "#CommandOutputParameter"
   doc: |
-    Only valid as a `type` for an output.
+    Only valid as a `type` for a `CommandLineTool` output with no
+    `outputBinding` set.
 
     The following
     ```

--- a/draft-4/CommandLineTool.yml
+++ b/draft-4/CommandLineTool.yml
@@ -359,14 +359,31 @@ $graph:
   extends: "#InputParameter"
   doc: An input parameter for a CommandLineTool.
   specialize:
-    - specializeFrom: "#InputRecordSchema"
-      specializeTo: "#CommandInputRecordSchema"
-    - specializeFrom: "#InputEnumSchema"
-      specializeTo: "#CommandInputEnumSchema"
-    - specializeFrom: "#InputArraySchema"
-      specializeTo: "#CommandInputArraySchema"
     - specializeFrom: "#InputBinding"
       specializeTo: "#CommandLineBinding"
+  fields:
+    - name: type
+      type:
+        - "null"
+        - "#CWLType"
+        - "#CommandInputRecordSchema"
+        - "#CommandInputEnumSchema"
+        - "#CommandInputArraySchema"
+        - string
+        - type: array
+          items:
+            - "#CWLType"
+            - "#CommandInputRecordSchema"
+            - "#CommandInputEnumSchema"
+            - "#CommandInputArraySchema"
+            - string
+      jsonldPredicate:
+        "_id": "sld:type"
+        "_type": "@vocab"
+        refScope: 2
+        typeDSL: True
+      doc: |
+        Specify valid types of data that may be assigned to this parameter.
 
 
 - type: record
@@ -374,12 +391,6 @@ $graph:
   extends: "#OutputParameter"
   doc: An output parameter for a CommandLineTool.
   specialize:
-    - specializeFrom: "#OutputRecordSchema"
-      specializeTo: "#CommandOutputRecordSchema"
-    - specializeFrom: "#OutputEnumSchema"
-      specializeTo: "#CommandOutputEnumSchema"
-    - specializeFrom: "#OutputArraySchema"
-      specializeTo: "#CommandOutputArraySchema"
     - specializeFrom: "#OutputBinding"
       specializeTo: "#CommandOutputBinding"
   fields:
@@ -389,16 +400,16 @@ $graph:
         - "#CWLType"
         - "#stdout"
         - "#stderr"
-        - "sld:RecordSchema"
-        - "sld:EnumSchema"
-        - "sld:ArraySchema"
+        - "#CommandOutputRecordSchema"
+        - "#CommandOutputEnumSchema"
+        - "#CommandOutputArraySchema"
         - string
         - type: array
           items:
             - "#CWLType"
-            - "sld:RecordSchema"
-            - "sld:EnumSchema"
-            - "sld:ArraySchema"
+            - "#CommandOutputRecordSchema"
+            - "#CommandOutputEnumSchema"
+            - "#CommandOutputArraySchema"
             - string
       jsonldPredicate:
         "_id": "sld:type"

--- a/draft-4/CommandLineTool.yml
+++ b/draft-4/CommandLineTool.yml
@@ -359,32 +359,14 @@ $graph:
   extends: "#InputParameter"
   doc: An input parameter for a CommandLineTool.
   specialize:
+    - specializeFrom: "#InputRecordSchema"
+      specializeTo: "#CommandInputRecordSchema"
+    - specializeFrom: "#InputEnumSchema"
+      specializeTo: "#CommandInputEnumSchema"
+    - specializeFrom: "#InputArraySchema"
+      specializeTo: "#CommandInputArraySchema"
     - specializeFrom: "#InputBinding"
       specializeTo: "#CommandLineBinding"
-  fields:
-    - name: type
-      type:
-        - "null"
-        - "#CWLType"
-        - "#CommandInputRecordSchema"
-        - "#CommandInputEnumSchema"
-        - "#CommandInputArraySchema"
-        - string
-        - type: array
-          items:
-            - "#CWLType"
-            - "#CommandInputRecordSchema"
-            - "#CommandInputEnumSchema"
-            - "#CommandInputArraySchema"
-            - string
-      jsonldPredicate:
-        "_id": "sld:type"
-        "_type": "@vocab"
-        refScope: 2
-        typeDSL: True
-      doc: |
-        Specify valid types of data that may be assigned to this parameter.
-
 
 - type: record
   name: CommandOutputParameter

--- a/draft-4/Process.yml
+++ b/draft-4/Process.yml
@@ -378,29 +378,6 @@ $graph:
     - specializeFrom: "sld:ArraySchema"
       specializeTo: "#InputArraySchema"
   fields:
-    - name: type
-      type:
-        - "null"
-        - "#CWLType"
-        - "sld:RecordSchema"
-        - "sld:EnumSchema"
-        - "sld:ArraySchema"
-        - string
-        - type: array
-          items:
-            - "#CWLType"
-            - "sld:RecordSchema"
-            - "sld:EnumSchema"
-            - "sld:ArraySchema"
-            - string
-      jsonldPredicate:
-        "_id": "sld:type"
-        "_type": "@vocab"
-        refScope: 2
-        typeDSL: True
-      doc: |
-        Specify valid types of data that may be assigned to this parameter.
-
     - name: id
       type: string
       jsonldPredicate: "@id"

--- a/draft-4/Process.yml
+++ b/draft-4/Process.yml
@@ -370,13 +370,6 @@ $graph:
 - name: InputParameter
   type: record
   extends: "#Parameter"
-  specialize:
-    - specializeFrom: "sld:RecordSchema"
-      specializeTo: "#InputRecordSchema"
-    - specializeFrom: "sld:EnumSchema"
-      specializeTo: "#InputEnumSchema"
-    - specializeFrom: "sld:ArraySchema"
-      specializeTo: "#InputArraySchema"
   fields:
     - name: id
       type: string
@@ -397,6 +390,28 @@ $graph:
         The default value for this parameter if not provided in the input
         object.
 
+    - name: type
+      type:
+        - "null"
+        - "#CWLType"
+        - "#InputRecordSchema"
+        - "#InputEnumSchema"
+        - "#InputArraySchema"
+        - string
+        - type: array
+          items:
+            - "#CWLType"
+            - "#InputRecordSchema"
+            - "#InputEnumSchema"
+            - "#InputArraySchema"
+            - string
+      jsonldPredicate:
+        "_id": "sld:type"
+        "_type": "@vocab"
+        refScope: 2
+        typeDSL: True
+      doc: |
+        Specify valid types of data that may be assigned to this parameter.
 
 - name: OutputParameter
   type: record

--- a/draft-4/Workflow.yml
+++ b/draft-4/Workflow.yml
@@ -104,6 +104,28 @@ $graph:
       doc: |
         The method to use to merge multiple sources into a single array.
         If not specified, the default method is "merge_nested".
+    - name: type
+      type:
+        - "null"
+        - "#CWLType"
+        - "#OutputRecordSchema"
+        - "#OutputEnumSchema"
+        - "#OutputArraySchema"
+        - string
+        - type: array
+          items:
+            - "#CWLType"
+            - "#OutputRecordSchema"
+            - "#OutputEnumSchema"
+            - "#OutputArraySchema"
+            - string
+      jsonldPredicate:
+        "_id": "sld:type"
+        "_type": "@vocab"
+        refScope: 2
+        typeDSL: True
+      doc: |
+        Specify valid types of data that may be assigned to this parameter.
 
 
 - name: Sink

--- a/draft-4/Workflow.yml
+++ b/draft-4/Workflow.yml
@@ -50,10 +50,39 @@ $graph:
 
     - {$include: concepts.md}
 
+- name: ExpressionToolOutputParameter
+  type: record
+  extends: Parameter
+  fields:
+    - name: type
+      type:
+        - "null"
+        - "#CWLType"
+        - "sld:RecordSchema"
+        - "sld:EnumSchema"
+        - "sld:ArraySchema"
+        - string
+        - type: array
+          items:
+            - "#CWLType"
+            - "sld:RecordSchema"
+            - "sld:EnumSchema"
+            - "sld:ArraySchema"
+            - string
+      jsonldPredicate:
+        "_id": "sld:type"
+        "_type": "@vocab"
+        refScope: 2
+        typeDSL: True
+      doc: |
+        Specify valid types of data that may be assigned to this parameter.
 
 - type: record
   name: ExpressionTool
   extends: Process
+  specialize:
+    - specializeFrom: "#OutputParameter"
+      specializeTo: "#ExpressionToolOutputParameter"
   documentRoot: true
   doc: |
     Execute an expression as a process step.


### PR DESCRIPTION
This is needed as there is no way to specialize just the allowable type for `CommandLineTool` outputs without copypasta with the current schema-salad