### PR TITLE
reparent file specific fields from SchemaBase to Parameter

### DIFF
--- a/draft-4/Process.yml
+++ b/draft-4/Process.yml
@@ -141,7 +141,29 @@ $graph:
 - name: SchemaBase
   type: record
   abstract: true
+
+
+- name: Parameter
+  type: record
+  extends: "#SchemaBase"
+  abstract: true
+  doc: |
+    Define an input or output parameter to a process.
+
   fields:
+    - name: label
+      type:
+        - "null"
+        - string
+      jsonldPredicate: "rdfs:label"
+      doc: "A short, human-readable label of this parameter object."
+
+    - name: description
+      type:
+        - "null"
+        - string
+      jsonldPredicate: "rdfs:comment"
+      doc: "A long, human-readable description of this parameter object."
     - name: secondaryFiles
       type:
         - "null"
@@ -198,29 +220,6 @@ $graph:
         sequentially without seeking.  An implementation may use this flag to
         indicate whether it is valid to stream file contents using a named
         pipe.  Default: `false`.
-
-
-- name: Parameter
-  type: record
-  extends: "#SchemaBase"
-  abstract: true
-  doc: |
-    Define an input or output parameter to a process.
-
-  fields:
-    - name: label
-      type:
-        - "null"
-        - string
-      jsonldPredicate: "rdfs:label"
-      doc: "A short, human-readable label of this parameter object."
-
-    - name: description
-      type:
-        - "null"
-        - string
-      jsonldPredicate: "rdfs:comment"
-      doc: "A long, human-readable description of this parameter object."
 
 
 - type: enum

--- a/draft-4/Workflow.yml
+++ b/draft-4/Workflow.yml
@@ -502,7 +502,7 @@ $graph:
   extends: ProcessRequirement
   doc: |
     Indicates that the workflow platform must support nested workflows in
-    the `run` field of (WorkflowStep)(#WorkflowStep).
+    the `run` field of [WorkflowStep](#WorkflowStep).
 
 - name: ScatterFeatureRequirement
   type: record


### PR DESCRIPTION
Proposed fix for https://github.com/common-workflow-language/common-workflow-language/issues/215

Looks like moving the `secondaryFiles`, `streamable`, and `format` fields from `cwl:SchemaBase` to `cwl:Parameter` preserves the intended behavior and removes them places they don't make sense: `{Input,Output}{Record,Enum,Array,,}Schema`

The conformance tests still pass and the docs still build with this change.