### PR TITLE
Describe `LooseDependencyHint`s.

### DIFF
--- a/draft-4/CommandLineTool.yml
+++ b/draft-4/CommandLineTool.yml
@@ -626,6 +626,27 @@ $graph:
         Docker container.
 
 
+- type: record
+  name: LooseDependencyHint
+  extends: "#ProcessRequirement"
+  doc: |
+    If a CommandLineTool is executed by a platform that is not configured to use
+    Docker, this dependency can annotate hints about the software that should
+    be configured in the environment of the defined process.
+
+    Absolute portability between platforms should be achieved with Docker, this
+    mechanism provides an inexact and imprecise fallback. The inexact nature of these
+    hints is due to this standard not specifying the base operating environment of
+    the process or how the that environment is to be configured as a result of these
+    hints. The imprecise nature of these hints is due to the `name` and `version`
+    fields being unstructured and not namespaced.
+  fields:
+    - name: name
+      type: ["string"]
+      doc: "The name of the software to be configured."
+    - name: "version"
+      type: ["null", "string"]
+      doc: "The (optional) version of the software to configured."
 
 - name: CreateFileRequirement
   type: record


### PR DESCRIPTION
Continue discussion from - https://github.com/common-workflow-language/cwltool/pull/93.

 - There was concern that stuff in cwltool should be in the standard. I think I agree so I've added it here.
 - I have renamed things and tried to make the language clear that we may have a more ... highly engineered ... solution later on that attempts to address the perceived problem that software package names are inconsistent. I've made the case ad nauseam that I do not believe this to be a serious problem or an insurmountable issue with the proposed cwltool implementation. But I've changed ``Dependency`` to ``LooseDependencyHint``  to show I'm willing to work with idealists on a "precise" and "ideal" solution. (Hopefully they can work with me on a pragmatic and proven solution :wink:.)
 - This is an uncharacteristically imprecise part of the standard - so I've made it clear that Docker provides greater precision and portability. I think there is absolutely value in describing this in the standard nonetheless, rather than forcing implementations to develop their own customizations we should describe generic ones that they can plug into.