### PR TITLE
Directory and file type schema

### DIFF
--- a/draft-3/examples/arguments.cwl
+++ b/draft-3/examples/arguments.cwl
@@ -1,5 +1,6 @@
 cwlVersion: cwl:draft-3
 class: CommandLineTool
+label: Example trivial wrapper for Java 7 compiler
 baseCommand: javac
 hints:
   - class: DockerRequirement

--- a/draft-4/CommandLineTool.yml
+++ b/draft-4/CommandLineTool.yml
@@ -646,6 +646,7 @@ $graph:
       type:
         - type: array
           items: DirentExt
+        - string
         - Expression
       jsonldPredicate:
         _id: "cwl:listing"

--- a/draft-4/CommandLineTool.yml
+++ b/draft-4/CommandLineTool.yml
@@ -79,30 +79,6 @@ $graph:
     - {$include: concepts.md}
     - {$include: invocation.md}
 
-- type: record
-  name: FileDef
-  doc: |
-    Define a file that must be placed in the designated output directory
-    prior to executing the command line tool.  May be the result of executing
-    an expression, such as building a configuration file from a template.
-  fields:
-    - name: "filename"
-      type: ["string", "#Expression"]
-      doc: "The name of the file to create in the output directory."
-    - name: "fileContent"
-      type: ["string", "#Expression"]
-      doc: |
-        If the value is a string literal or an expression which evaluates to a
-        string, a new file must be created with the string as the file contents.
-
-        If the value is an expression that evaluates to a File object, this
-        indicates the referenced file should be added to the designated output
-        directory prior to executing the tool.
-
-        Files added in this way may be read-only, and may be provided
-        by bind mounts or file system links to avoid
-        unnecessary copying of the input file.
-
 
 - type: record
   name: EnvironmentDef
@@ -628,20 +604,53 @@ $graph:
 
 - name: DirentExt
   type: record
+  doc: |
+    Define a file or subdirectory that must be placed in the designated output
+    directory prior to executing the command line tool.  May be the result of
+    executing an expression, such as building a configuration file from a
+    template.
   fields:
     - name: entryname
       type: [string, Expression]
       jsonldPredicate:
         _id: cwl:entryname
+      doc: |
+        The name of the file or subdirectory to create in the output directory.
     - name: entry
       type: [string, Expression]
       jsonldPredicate:
         _id: cwl:entry
+      doc: |
+        If the value is a string literal or an expression which evaluates to a
+        string, a new file must be created with the string as the file contents.
 
+        If the value is an expression that evaluates to a `File` object, this
+        indicates the referenced file should be added to the designated output
+        directory prior to executing the tool.
+
+        If the value is an expression that evaluates to a `Dirent` object, this
+        indicates that the File or Directory in `entry` should be added to the
+        designated output directory with the name in `entryname`.
+
+        If `writable` is false, the file may be made available using a bind
+        mount or file system link to avoid unnecessary copying of the input
+        file.
+    - name: writable
+      type: boolean?
+      doc: |
+        If true, the file or directory must be writable by the tool.  Changes
+        to the file or directory must be isolated and not visible by any other
+        CommandLineTool process.  This may be implemented by making a copy of
+        the original file or directory.  Default false (files and directories
+        read-only by default).
 
 - name: InitialWorkDirRequirement
   type: record
   extends: ProcessRequirement
+  doc:
+    Define a list of files and subdirectories that must be created by the
+    workflow platform in the designated output directory prior to executing the
+    command line tool.
   fields:
     - name: listing
       type:
@@ -653,24 +662,12 @@ $graph:
         _id: "cwl:listing"
         mapSubject: entryname
         mapPredicate: entry
+      doc: |
+        The list of files or subdirectories that must be placed in the
+        designated output directory prior to executing the command line tool.
 
-
-- name: CreateFileRequirement
-  type: record
-  extends: "#ProcessRequirement"
-  doc: |
-    *Deprecated*, superceded by InitialWorkDirRequirement.
-
-    Define a list of files that must be created by the workflow
-    platform in the designated output directory prior to executing the command
-    line tool.  See `FileDef` for details.
-  fields:
-    - name: fileDef
-      type:
-        type: "array"
-        items: "#FileDef"
-      doc: The list of files.
-
+        May be an expression.  If so, the expression return value must validate
+        as `{type: array, items: [File, Dirent]}`.
 
 - name: EnvVarRequirement
   type: record

--- a/draft-4/CommandLineTool.yml
+++ b/draft-4/CommandLineTool.yml
@@ -626,11 +626,39 @@ $graph:
         Docker container.
 
 
+- name: DirentExt
+  type: record
+  fields:
+    - name: entryname
+      type: [string, Expression]
+      jsonldPredicate:
+        "_id": cwl:entryname
+    - name: entry
+      type: [string, Expression]
+        "_id": cwl:entry
+
+
+- name: InitialWorkDirRequirement
+  type: record
+  extends: ProcessRequirement
+  fields:
+    - name: listing
+      type:
+        - type: array
+          items: DirentExt
+        - Expression
+      jsonldPredicate:
+        _id: "cwl:listing"
+        mapSubject: entryname
+        mapPredicate: entry
+
 
 - name: CreateFileRequirement
   type: record
   extends: "#ProcessRequirement"
   doc: |
+    *Deprecated*, superceded by InitialWorkDirRequirement.
+
     Define a list of files that must be created by the workflow
     platform in the designated output directory prior to executing the command
     line tool.  See `FileDef` for details.

--- a/draft-4/CommandLineTool.yml
+++ b/draft-4/CommandLineTool.yml
@@ -646,7 +646,7 @@ $graph:
     - name: listing
       type:
         - type: array
-          items: DirentExt
+          items: [File, DirentExt]
         - string
         - Expression
       jsonldPredicate:

--- a/draft-4/CommandLineTool.yml
+++ b/draft-4/CommandLineTool.yml
@@ -632,10 +632,11 @@ $graph:
     - name: entryname
       type: [string, Expression]
       jsonldPredicate:
-        "_id": cwl:entryname
+        _id: cwl:entryname
     - name: entry
       type: [string, Expression]
-        "_id": cwl:entry
+      jsonldPredicate:
+        _id: cwl:entry
 
 
 - name: InitialWorkDirRequirement

--- a/draft-4/CommandLineTool.yml
+++ b/draft-4/CommandLineTool.yml
@@ -425,7 +425,7 @@ $graph:
       type:
         - "null"
         - type: array
-          items: [string, "#CommandLineBinding"]
+          items: [string, "#Expression", "#CommandLineBinding"]
       jsonldPredicate:
         "_id": "cwl:arguments"
         "_container": "@list"

--- a/draft-4/CommandLineTool.yml
+++ b/draft-4/CommandLineTool.yml
@@ -224,17 +224,6 @@ $graph:
         the File objects must include up to the first 64 KiB of file contents
         in the `contents` field.
 
-- name: initialWorkDir
-  type: record
-  doc: |
-    Setup a working directory based on a number of input files (and/or directories)
-  fields:
-    - name: dirDef
-      type:
-        type: "array"
-        items: [ "#FileDef", "#File", "#Directory" ]
-      doc: list of files and/or directories
-
 
 - name: CommandInputRecordField
   type: record

--- a/draft-4/Process.yml
+++ b/draft-4/Process.yml
@@ -145,6 +145,7 @@ $graph:
         - "null"
         - type: array
           items: "#File"
+        - Directory
       jsonldPredicate: "cwl:secondaryFiles"
       doc: |
         A list of additional files that are associated with the primary file

--- a/draft-4/Process.yml
+++ b/draft-4/Process.yml
@@ -142,13 +142,13 @@ $graph:
         _type: "@vocab"
       doc: Must be `Directory` to indicate this object describes a Directory.
     - name: path
-      type: string
+      type: string?
       doc: The path to the directory.
       jsonldPredicate:
         _id: "cwl:path"
         _type: "@id"
     - name: listing
-      type: Dirent[]
+      type: Dirent[]?
       doc: List of files or subdirectories contained in this directory
       jsonldPredicate:
         _id: "cwl:listing"

--- a/draft-4/Process.yml
+++ b/draft-4/Process.yml
@@ -60,20 +60,82 @@ $graph:
         symbols:
           - cwl:File
       jsonldPredicate:
-        "_id": "@type"
-        "_type": "@vocab"
+        _id: "@type"
+        _type: "@vocab"
       doc: Must be `File` to indicate this object describes a file.
+    - name: location
+      type: string?
+      doc: |
+        A URI that identifies the file resource.  This may be a relative
+        reference, in which case it must be resolved using the base URI of the
+        document.  The location may refer to a local or remote resource; the
+        implementation must use the URI to retrieve file content.  If an
+        implementation is unable to retrieve the file content stored at a
+        remote resource (due to unsupported protocol, access denied, or other
+        issue) it must signal an error.
+      jsonldPredicate:
+        _id: "@id"
+        _type: "@id"
     - name: path
-      type: string
-      doc: The path to the file.
+      type: string?
+      doc: |
+        The local path where the File is made available prior to executing a
+        CommandLineTool.  This field must not be used in any other context.  The
+        command line tool being executed must be able to to access the file at
+        `path` using the POSIX `open(2)` syscall.
       jsonldPredicate:
         "_id": "cwl:path"
         "_type": "@id"
+    - name: basename
+      type: string?
+      doc: |
+        The base name of the file, that is, the path component following the
+        final slash in the path.
+
+        The implementation must set this field based on the value of `path`
+        prior to evaluating parameter references or expressions in a
+        CommandLineTool document.  This field must not be used in any other
+        context.
+    - name: dirname
+      type: string?
+      doc: |
+        The name of the directory containing file, that is, the path leading up
+        to the final slash in the path such that `dirname + '/' + basename =
+        path`.
+
+        The implementation must set this field based on the value of `path`
+        prior to evaluating parameter references or expressions in a
+        CommandLineTool document.  This field must not be used in any other
+        context.
+    - name: nameroot
+      type: string?
+      doc: |
+        The basename root such that `nameroot + nameext == basename`, and
+        `nameext` is empty or begins with a period and contains at most one
+        period.  Leading periods on the basename are ignored; a basename of
+        `.cshrc` will have a nameroot of `.cshrc`.
+
+        The implementation must set this field based on the value of `path`
+        prior to evaluating parameter references or expressions in a
+        CommandLineTool document.  This field must not be used in any other
+        context.
+    - name: nameext
+      type: string?
+      doc: |
+        The basename extension such that `nameroot + nameext == basename`, and
+        `nameext` is empty or begins with a period and contains at most one
+        period.  Leading periods on the basename are ignored; a basename of
+        `.cshrc` will have an empty `nameext`.
+
+        The implementation must set this field based on the value of `path`
+        prior to evaluating parameter references or expressions in a
+        CommandLineTool document.  This field must not be used in any other
+        context.
     - name: checksum
       type: ["null", string]
       doc: |
         Optional hash code for validating file integrity.  Currently must be in the form
-        "sha1$ + hexidecimal string" using the SHA-1 algorithm.
+        "sha1$ + hexadecimal string" using the SHA-1 algorithm.
     - name: size
       type: ["null", long]
       doc: Optional file size.
@@ -141,6 +203,10 @@ $graph:
         _id: "@type"
         _type: "@vocab"
       doc: Must be `Directory` to indicate this object describes a Directory.
+    - name: id
+      type: string
+      doc: A URI used to identify the directory.
+      jsonldPredicate: "@id"
     - name: path
       type: string?
       doc: The path to the directory.

--- a/draft-4/Process.yml
+++ b/draft-4/Process.yml
@@ -33,6 +33,7 @@ $graph:
     - cwl:draft-3
     - cwl:draft-4.dev1
     - cwl:draft-4.dev2
+    - cwl:draft-4.dev3
 
 - name: CWLType
   type: enum

--- a/draft-4/Process.yml
+++ b/draft-4/Process.yml
@@ -203,10 +203,19 @@ $graph:
         _id: "@type"
         _type: "@vocab"
       doc: Must be `Directory` to indicate this object describes a Directory.
-    - name: id
+    - name: location
       type: string
-      doc: A URI used to identify the directory.
-      jsonldPredicate: "@id"
+      doc: |
+        A URI that identifies the directory resource.  This may be a relative
+        reference, in which case it must be resolved using the base URI of the
+        document.  The location may refer to a local or remote resource.  If
+        the `listing` field is not set, the implementation must use the URI to
+        retrieve directory listing.  If an implementation is unable to retrieve
+        the file content stored at a remote resource (due to unsupported
+        protocol, access denied, or other issue) it must signal an error.
+      jsonldPredicate:
+        _id: "@id"
+        _type: "@id"
     - name: path
       type: string?
       doc: The path to the directory.

--- a/draft-4/Process.yml
+++ b/draft-4/Process.yml
@@ -144,8 +144,7 @@ $graph:
       type:
         - "null"
         - type: array
-          items: "#File"
-        - Directory
+          items: [File, Dirent]
       jsonldPredicate: "cwl:secondaryFiles"
       doc: |
         A list of additional files that are associated with the primary file

--- a/draft-4/Process.yml
+++ b/draft-4/Process.yml
@@ -225,7 +225,10 @@ $graph:
         _id: "cwl:path"
         _type: "@id"
     - name: listing
-      type: Dirent[]?
+      type:
+        - "null"
+        - type: array
+          items: [File, Dirent]
       doc: List of files or subdirectories contained in this directory
       jsonldPredicate:
         _id: "cwl:listing"

--- a/draft-4/Process.yml
+++ b/draft-4/Process.yml
@@ -186,7 +186,8 @@ $graph:
         "_id": cwl:entryname
     - name: entry
       type: [File, Directory]
-
+      jsonldPredicate:
+        "_id": cwl:entry
 
 - name: Directory
   type: record
@@ -229,7 +230,7 @@ $graph:
       doc: List of files or subdirectories contained in this directory
       jsonldPredicate:
         _id: "cwl:listing"
-        mapSubject: basename
+        mapSubject: entryname
         mapPredicate: entry
 
 - name: SchemaBase

--- a/draft-4/Process.yml
+++ b/draft-4/Process.yml
@@ -39,9 +39,11 @@ $graph:
   extends: "sld:PrimitiveType"
   symbols:
     - cwl:File
+    - cwl:Directory
   doc:
     - "Extends primitive types with the concept of a file as a first class type."
     - "File: A File object"
+    - "Directory: A Directory object"
 
 - name: File
   type: record
@@ -111,12 +113,23 @@ $graph:
         runtime may perform exact file format matches.
 
 
+- name: Dirent
+  type: record
+  fields:
+    - name: basename
+      type: string
+      jsonldPredicate:
+        "_id": cwl:name
+    - name: entry
+      type: [File, Directory]
+
+
 - name: Directory
   type: record
   docParent: "#CWLType"
   doc: |
     Represents a directory to present to a command line tool. This could be a virtual
-    directory, made of files assembled from a number of concrete directories.
+    directory, made of files assembled from multiple locations.
   fields:
     - name: class
       type:
@@ -125,18 +138,22 @@ $graph:
         symbols:
           - cwl:Directory
       jsonldPredicate:
-        "_id": "@type"
-        "_type": "@vocab"
+        _id: "@type"
+        _type: "@vocab"
       doc: Must be `Directory` to indicate this object describes a Directory.
     - name: path
       type: string
       doc: The path to the directory.
       jsonldPredicate:
-        "_id": "cwl:path"
-        "_type": "@id"
-    # - name: size
-    #   type: ["null", long]
-    #   doc: Optional directory size.
+        _id: "cwl:path"
+        _type: "@id"
+    - name: listing
+      type: Dirent[]
+      doc: List of files or subdirectories contained in this directory
+      jsonldPredicate:
+        _id: "cwl:listing"
+        mapSubject: basename
+        mapPredicate: entry
 
 
 - name: SchemaBase

--- a/draft-4/Process.yml
+++ b/draft-4/Process.yml
@@ -64,7 +64,7 @@ $graph:
         _type: "@vocab"
       doc: Must be `File` to indicate this object describes a file.
     - name: location
-      type: string?
+      type: string
       doc: |
         A URI that identifies the file resource.  This may be a relative
         reference, in which case it must be resolved using the base URI of the
@@ -178,10 +178,10 @@ $graph:
 - name: Dirent
   type: record
   fields:
-    - name: basename
+    - name: entryname
       type: string
       jsonldPredicate:
-        "_id": cwl:name
+        "_id": cwl:entryname
     - name: entry
       type: [File, Directory]
 

--- a/draft-4/Process.yml
+++ b/draft-4/Process.yml
@@ -74,6 +74,10 @@ $graph:
         implementation is unable to retrieve the file content stored at a
         remote resource (due to unsupported protocol, access denied, or other
         issue) it must signal an error.
+
+        If the `path` field is provided but the `location` field is not, an
+        implementation may assign the value of the `path` field to `location`,
+        then follow the rules above.
       jsonldPredicate:
         _id: "@id"
         _type: "@id"
@@ -81,9 +85,10 @@ $graph:
       type: string?
       doc: |
         The local path where the File is made available prior to executing a
-        CommandLineTool.  This field must not be used in any other context.  The
-        command line tool being executed must be able to to access the file at
-        `path` using the POSIX `open(2)` syscall.
+        CommandLineTool.  This must be set by the implementation.  This field
+        must not be used in any other context.  The command line tool being
+        executed must be able to to access the file at `path` using the POSIX
+        `open(2)` syscall.
       jsonldPredicate:
         "_id": "cwl:path"
         "_type": "@id"
@@ -211,16 +216,26 @@ $graph:
         A URI that identifies the directory resource.  This may be a relative
         reference, in which case it must be resolved using the base URI of the
         document.  The location may refer to a local or remote resource.  If
-        the `listing` field is not set, the implementation must use the URI to
-        retrieve directory listing.  If an implementation is unable to retrieve
-        the file content stored at a remote resource (due to unsupported
-        protocol, access denied, or other issue) it must signal an error.
+        the `listing` field is not set, the implementation must use the
+        location URI to retrieve directory listing.  If an implementation is
+        unable to retrieve the directory listing stored at a remote resource (due to
+        unsupported protocol, access denied, or other issue) it must signal an
+        error.
+
+        If the `path` field is provided but the `location` field is not, an
+        implementation may assign the value of the `path` field to `location`,
+        then follow the rules above.
       jsonldPredicate:
         _id: "@id"
         _type: "@id"
     - name: path
       type: string?
-      doc: The path to the directory.
+      doc: |
+        The local path where the Directory is made available prior to executing a
+        CommandLineTool.  This must be set by the implementation.  This field
+        must not be used in any other context.  The command line tool being
+        executed must be able to to access the directory at `path` using the POSIX
+        `opendir(2)` syscall.
       jsonldPredicate:
         _id: "cwl:path"
         _type: "@id"

--- a/draft-4/conformance_test_draft-4.yaml
+++ b/draft-4/conformance_test_draft-4.yaml
@@ -771,3 +771,15 @@
   }
   tool: draft-4/dir5.cwl
   doc: Test dynamic initial work dir
+
+- job: draft-4/stagefile-job.yml
+  output: {
+    "outfile": {
+        "checksum": "sha1$2d6c5e4430c4b200227cc77d3b0025082505ee19",
+        "size": 1107,
+        "location": "whale.txt",
+        "class": "File"
+    }
+  }
+  tool: draft-4/stagefile.cwl
+  doc: Test writable staged files.

--- a/draft-4/conformance_test_draft-4.yaml
+++ b/draft-4/conformance_test_draft-4.yaml
@@ -647,3 +647,50 @@
   }
   tool: "draft-4/conflict-wf.cwl#collision"
   doc: Test workflow two input files with same name.
+
+- job: draft-4/dir-job.yml
+  output:
+    "outlist": {
+        "size": 20,
+        "path": "output.txt",
+        "checksum": "sha1$13cda8661796ae241da3a18668fb552161a72592",
+        "class": "File"
+    }
+  tool: draft-4/dir.cwl
+  doc: Test directory input
+
+- job: draft-4/dir-job.yml
+  output:
+    "outlist": {
+        "size": 20,
+        "path": "output.txt",
+        "checksum": "sha1$13cda8661796ae241da3a18668fb552161a72592",
+        "class": "File"
+    }
+  tool: draft-4/dir2.cwl
+  doc: Test directory input in Docker
+
+- job: draft-4/dir3-job.yml
+  output:
+    "outdir": {
+        "class": "Directory",
+        "hostfs": true,
+        "listing": [
+            {
+                "basename": "hello.txt",
+                "entry": {
+                    "class": "File",
+                    "path": "hello.txt"
+                }
+            },
+            {
+                "basename": "goodbye.txt",
+                "entry": {
+                    "class": "File",
+                    "path": "goodbye.txt"
+                }
+            }
+        ],
+    }
+  tool: draft-4/dir3.cwl
+  doc: Test directory input in Docker

--- a/draft-4/conformance_test_draft-4.yaml
+++ b/draft-4/conformance_test_draft-4.yaml
@@ -719,14 +719,14 @@
         "class": "Directory",
         "listing": [
             {
-                "basename": "hello.txt",
+                "entryname": "hello.txt",
                 "entry": {
                     "class": "File",
                     "location": "hello.txt"
                 }
             },
             {
-                "basename": "goodbye.txt",
+                "entryname": "goodbye.txt",
                 "entry": {
                     "class": "File",
                     "location": "goodbye.txt"

--- a/draft-4/conformance_test_draft-4.yaml
+++ b/draft-4/conformance_test_draft-4.yaml
@@ -736,3 +736,27 @@
     }
   tool: draft-4/dir3.cwl
   doc: Test directory input in Docker
+
+- job: draft-4/dir4-job.yml
+  output:
+    "outlist": {
+        "size": 20,
+        "location": "output.txt",
+        "checksum": "sha1$13cda8661796ae241da3a18668fb552161a72592",
+        "class": "File"
+    }
+  tool: draft-4/dir4.cwl
+  doc: Test directories in secondaryFiles
+
+- job: draft-4/dir-job.yml
+  output: {
+    "outlist": {
+        "checksum": "sha1$907a866a3e0b7f1fc5a2222531c5fb9063704438",
+        "path": "/home/peter/work/common-workflow-language/draft-4/draft-4/output.txt",
+        "size": 33,
+        "location": "file:///home/peter/work/common-workflow-language/draft-4/draft-4/output.txt",
+        "class": "File"
+    }
+  }
+  tool: draft-4/dir5.cwl
+  doc: Test dynamic initial work dir

--- a/draft-4/conformance_test_draft-4.yaml
+++ b/draft-4/conformance_test_draft-4.yaml
@@ -77,28 +77,39 @@
   tool: draft-4/cat3-tool-mediumcut.cwl
   doc: Test command execution in Docker with stdout redirection
 
-# - args: [egrep]
-#   stderr: error.txt
-#   job:
-#   tool: draft-4/egrep-stderr.cwl
-#   doc: Test command line with stderr redirection
+- job:
+  output: {
+    "output_file": {
+        "checksum": "sha1$cec7b8746a78c42060c96505887449bca0142976",
+        "size": 84,
+        "location": "error.txt",
+        "class": "File"
+    }
+  }
+  tool: draft-4/egrep-stderr.cwl
+  doc: Test command line with stderr redirection
 
-# - args: [egrep]
-#   job:
-#   tool: draft-4/egrep-stderr-shortcut.cwl
-#   doc: Test command line with stderr redirection, brief syntax
+- job:
+  output: {
+    "output_file": {
+        "checksum": "sha1$cec7b8746a78c42060c96505887449bca0142976",
+        "size": 84,
+        "location": "",
+        "class": "File"
+    }
+  }
+  tool: draft-4/egrep-stderr-shortcut.cwl
+  doc: Test command line with stderr redirection, brief syntax
 
-# - args: [egrep]
-#   stderr: std.err
-#   output:
-#     output_file:
-#       class: File
-#       size: 84
-#       checksum: sha1$cec7b8746a78c42060c96505887449bca0142976
-#       location: std.err
-#   job:
-#   tool: draft-4/egrep-stderr-mediumcut.cwl
-#   doc: Test command line with stderr redirection, named brief syntax
+- output:
+    output_file:
+      class: File
+      size: 84
+      checksum: sha1$cec7b8746a78c42060c96505887449bca0142976
+      location: std.err
+  job:
+  tool: draft-4/egrep-stderr-mediumcut.cwl
+  doc: Test command line with stderr redirection, named brief syntax
 
 - job: draft-4/cat-job.json
   output:

--- a/draft-4/conformance_test_draft-4.yaml
+++ b/draft-4/conformance_test_draft-4.yaml
@@ -41,7 +41,10 @@
         "checksum": "sha1$63da67422622fbf9251a046d7a34b7ea0fd4fead",
         "class": "File",
         "path": "foo.txt",
-        "size": 22
+        "size": 22,
+        "basename": "foo.txt",
+        "nameext": ".txt",
+        "nameroot": "foo"
     }
   job: draft-4/cat-job.json
   tool: draft-4/template-tool.cwl
@@ -54,6 +57,9 @@
       checksum: sha1$47a013e660d408619d894b20806b1d5086aab03b
       path: output.txt
       size: 13
+      basename: output.txt
+      nameext: .txt
+      nameroot: output
   tool: draft-4/cat3-tool.cwl
   doc: Test command execution in Docker with stdout redirection
 
@@ -64,6 +70,9 @@
       checksum: sha1$47a013e660d408619d894b20806b1d5086aab03b
       path: output.txt
       size: 13
+      basename: output.txt
+      nameext: .txt
+      nameroot: output
   tool: draft-4/cat4-tool.cwl
   doc: Test command execution in Docker with stdin and stdout redirection
 
@@ -109,6 +118,9 @@
       checksum: sha1$631bfbac524e2d04cdcc5ec33ade827fc10b06ae
       path: output
       size: 15
+      basename: output
+      nameext: ""
+      nameroot: output
   tool: draft-4/wc-tool.cwl
   doc: Test command execution in with stdin and stdout redirection
 
@@ -179,6 +191,9 @@
       checksum: sha1$b3ec4ed1749c207e52b3a6d08c59f31d83bff519
       path: out
       size: 15
+      basename: out
+      nameext: ""
+      nameroot: out
   tool: draft-4/env-tool1.cwl
   doc: Test EnvVarRequirement
 
@@ -224,6 +239,9 @@
       checksum: sha1$b3ec4ed1749c207e52b3a6d08c59f31d83bff519
       path: out
       size: 15
+      basename: out
+      nameext: ""
+      nameroot: out
   tool: draft-4/env-wf1.cwl
   doc: Test requirement priority
 
@@ -234,6 +252,9 @@
       checksum: sha1$cdc1e84968261d6a7575b5305945471f8be199b6
       path: out
       size: 9
+      basename: out
+      nameext: ""
+      nameroot: out
   tool: draft-4/env-wf2.cwl
   doc: Test requirements override hints
 
@@ -249,6 +270,9 @@
       checksum: sha1$b9214658cc453331b62c2282b772a5c063dbd284
       path: output.txt
       size: 1111
+      basename: output.txt
+      nameext: .txt
+      nameroot: output
   tool: draft-4/revsort.cwl
   doc: Test sample workflows from the specification
 
@@ -259,6 +283,9 @@
       checksum: sha1$47a013e660d408619d894b20806b1d5086aab03b
       path: output.txt
       size: 13
+      basename: output.txt
+      nameext: .txt
+      nameroot: output
   tool: draft-4/cat5-tool.cwl
   doc: Test unknown hints are ignored.
 
@@ -269,30 +296,51 @@
       checksum: sha1$e2dc9daaef945ac15f01c238ed2f1660f60909a0
       path: result.txt
       size: 142
+      basename: result.txt
+      nameext: .txt
+      nameroot: result
     indexedfile: {
         "path": "input.txt",
+        "basename": "input.txt",
+        "nameext": ".txt",
+        "nameroot": "input",
         "class": "File",
         "checksum": "sha1$327fc7aedf4f6b69a42a7c8b808dc5a7aff61376",
         "secondaryFiles": [
             {
                 "path": "input.txt.idx1",
-                "class": "File"
+                "class": "File",
+                "basename": "input.txt.idx1",
+                "nameext": ".idx1",
+                "nameroot": "input.txt",
             },
             {
                 "path": "input.idx2",
-                "class": "File"
+                "class": "File",
+                "basename": "input.idx2",
+                "nameext": ".idx2",
+                "nameroot": "input",
             },
             {
                 "path": "input.txt.idx3",
-                "class": "File"
+                "class": "File",
+                "basename": "input.txt.idx3",
+                "nameext": ".idx3",
+                "nameroot": "input.txt",
             },
             {
                 "path": "input.txt.idx4",
-                "class": "File"
+                "class": "File",
+                "basename": "input.txt.idx4",
+                "nameext": ".idx4",
+                "nameroot": "input.txt",
             },
             {
                 "path": "input.txt.idx5",
-                "class": "File"
+                "class": "File",
+                "basename": "input.txt.idx5",
+                "nameext": ".idx5",
+                "nameroot": "input.txt",
             }
         ],
         "size": 1111
@@ -309,6 +357,9 @@
       checksum: sha1$327fc7aedf4f6b69a42a7c8b808dc5a7aff61376
       path: fish.txt
       size: 1111
+      basename: fish.txt
+      nameext: .txt
+      nameroot: fish
   tool: draft-4/rename.cwl
   doc: |
     Test CreateFileRequirement with expression in filename.
@@ -327,6 +378,9 @@
         size: 12
         class: File
         checksum: "sha1$f12e6cfe70f3253f70b0dbde17c692e7fb0f1e5e"
+        basename: output.txt
+        nameext: .txt
+        nameroot: output
   tool: draft-4/schemadef-tool.cwl
   doc: |
     Test SchemaDefRequirement definition used in tool parameter
@@ -338,6 +392,9 @@
         size: 12
         class: File
         checksum: "sha1$f12e6cfe70f3253f70b0dbde17c692e7fb0f1e5e"
+        basename: output.txt
+        nameext: .txt
+        nameroot: output
   tool: draft-4/schemadef-wf.cwl
   doc: |
     Test SchemaDefRequirement definition used in workflow parameter
@@ -542,6 +599,9 @@
         size: 13
         class: "File"
         checksum: "sha1$47a013e660d408619d894b20806b1d5086aab03b"
+        basename: output.txt
+        nameext: .txt
+        nameroot: output
   doc: |
     Test optional output file and optional secondaryFile on output.
 
@@ -674,7 +734,6 @@
   output:
     "outdir": {
         "class": "Directory",
-        "hostfs": true,
         "listing": [
             {
                 "basename": "hello.txt",

--- a/draft-4/conformance_test_draft-4.yaml
+++ b/draft-4/conformance_test_draft-4.yaml
@@ -40,11 +40,8 @@
     "foo": {
         "checksum": "sha1$63da67422622fbf9251a046d7a34b7ea0fd4fead",
         "class": "File",
-        "path": "foo.txt",
-        "size": 22,
-        "basename": "foo.txt",
-        "nameext": ".txt",
-        "nameroot": "foo"
+        "location": "foo.txt",
+        "size": 22
     }
   job: draft-4/cat-job.json
   tool: draft-4/template-tool.cwl
@@ -55,61 +52,61 @@
     output_file:
       class: File
       checksum: sha1$47a013e660d408619d894b20806b1d5086aab03b
-      path: output.txt
+      location: output.txt
       size: 13
-      basename: output.txt
-      nameext: .txt
-      nameroot: output
   tool: draft-4/cat3-tool.cwl
   doc: Test command execution in Docker with stdout redirection
 
 - job: draft-4/cat-job.json
   tool: draft-4/cat3-tool-shortcut.cwl
-  doc: Test command execution in Docker with stdout redirection
+  output:
+    output_file:
+      class: File
+      checksum: sha1$47a013e660d408619d894b20806b1d5086aab03b
+      location:
+      size: 13
+  doc: Test command execution in Docker with simplified syntax stdout redirection
 
 - job: draft-4/cat-job.json
   output:
     output_file:
       class: File
       checksum: sha1$47a013e660d408619d894b20806b1d5086aab03b
-      path: cat-out
+      location: cat-out
       size: 13
   tool: draft-4/cat3-tool-mediumcut.cwl
   doc: Test command execution in Docker with stdout redirection
 
-- args: [egrep]
-  stderr: error.txt
-  job:
-  tool: draft-4/egrep-stderr.cwl
-  doc: Test command line with stderr redirection
+# - args: [egrep]
+#   stderr: error.txt
+#   job:
+#   tool: draft-4/egrep-stderr.cwl
+#   doc: Test command line with stderr redirection
 
-- args: [egrep]
-  job:
-  tool: draft-4/egrep-stderr-shortcut.cwl
-  doc: Test command line with stderr redirection, brief syntax
+# - args: [egrep]
+#   job:
+#   tool: draft-4/egrep-stderr-shortcut.cwl
+#   doc: Test command line with stderr redirection, brief syntax
 
-- args: [egrep]
-  stderr: std.err
-  output:
-    output_file:
-      class: File
-      size: 84
-      checksum: sha1$cec7b8746a78c42060c96505887449bca0142976
-      path: std.err
-  job:
-  tool: draft-4/egrep-stderr-mediumcut.cwl
-  doc: Test command line with stderr redirection, named brief syntax
+# - args: [egrep]
+#   stderr: std.err
+#   output:
+#     output_file:
+#       class: File
+#       size: 84
+#       checksum: sha1$cec7b8746a78c42060c96505887449bca0142976
+#       location: std.err
+#   job:
+#   tool: draft-4/egrep-stderr-mediumcut.cwl
+#   doc: Test command line with stderr redirection, named brief syntax
 
 - job: draft-4/cat-job.json
   output:
     output_txt:
       class: File
       checksum: sha1$47a013e660d408619d894b20806b1d5086aab03b
-      path: output.txt
+      location: output.txt
       size: 13
-      basename: output.txt
-      nameext: .txt
-      nameroot: output
   tool: draft-4/cat4-tool.cwl
   doc: Test command execution in Docker with stdin and stdout redirection
 
@@ -153,11 +150,8 @@
     output:
       class: File
       checksum: sha1$631bfbac524e2d04cdcc5ec33ade827fc10b06ae
-      path: output
+      location: output
       size: 15
-      basename: output
-      nameext: ""
-      nameroot: output
   tool: draft-4/wc-tool.cwl
   doc: Test command execution in with stdin and stdout redirection
 
@@ -226,11 +220,8 @@
     out:
       class: File
       checksum: sha1$b3ec4ed1749c207e52b3a6d08c59f31d83bff519
-      path: out
+      location: out
       size: 15
-      basename: out
-      nameext: ""
-      nameroot: out
   tool: draft-4/env-tool1.cwl
   doc: Test EnvVarRequirement
 
@@ -274,11 +265,8 @@
     out:
       class: File
       checksum: sha1$b3ec4ed1749c207e52b3a6d08c59f31d83bff519
-      path: out
+      location: out
       size: 15
-      basename: out
-      nameext: ""
-      nameroot: out
   tool: draft-4/env-wf1.cwl
   doc: Test requirement priority
 
@@ -287,11 +275,8 @@
     out:
       class: File
       checksum: sha1$cdc1e84968261d6a7575b5305945471f8be199b6
-      path: out
+      location: out
       size: 9
-      basename: out
-      nameext: ""
-      nameroot: out
   tool: draft-4/env-wf2.cwl
   doc: Test requirements override hints
 
@@ -305,11 +290,8 @@
     output:
       class: File
       checksum: sha1$b9214658cc453331b62c2282b772a5c063dbd284
-      path: output.txt
+      location: output.txt
       size: 1111
-      basename: output.txt
-      nameext: .txt
-      nameroot: output
   tool: draft-4/revsort.cwl
   doc: Test sample workflows from the specification
 
@@ -318,11 +300,8 @@
     output_file:
       class: File
       checksum: sha1$47a013e660d408619d894b20806b1d5086aab03b
-      path: output.txt
+      location: output.txt
       size: 13
-      basename: output.txt
-      nameext: .txt
-      nameroot: output
   tool: draft-4/cat5-tool.cwl
   doc: Test unknown hints are ignored.
 
@@ -331,53 +310,32 @@
     outfile:
       class: File
       checksum: sha1$e2dc9daaef945ac15f01c238ed2f1660f60909a0
-      path: result.txt
+      location: result.txt
       size: 142
-      basename: result.txt
-      nameext: .txt
-      nameroot: result
     indexedfile: {
-        "path": "input.txt",
-        "basename": "input.txt",
-        "nameext": ".txt",
-        "nameroot": "input",
+        "location": "input.txt",
         "class": "File",
         "checksum": "sha1$327fc7aedf4f6b69a42a7c8b808dc5a7aff61376",
         "secondaryFiles": [
             {
-                "path": "input.txt.idx1",
+                "location": "input.txt.idx1",
                 "class": "File",
-                "basename": "input.txt.idx1",
-                "nameext": ".idx1",
-                "nameroot": "input.txt",
             },
             {
-                "path": "input.idx2",
+                "location": "input.idx2",
                 "class": "File",
-                "basename": "input.idx2",
-                "nameext": ".idx2",
-                "nameroot": "input",
             },
             {
-                "path": "input.txt.idx3",
+                "location": "input.txt.idx3",
                 "class": "File",
-                "basename": "input.txt.idx3",
-                "nameext": ".idx3",
-                "nameroot": "input.txt",
             },
             {
-                "path": "input.txt.idx4",
+                "location": "input.txt.idx4",
                 "class": "File",
-                "basename": "input.txt.idx4",
-                "nameext": ".idx4",
-                "nameroot": "input.txt",
             },
             {
-                "path": "input.txt.idx5",
+                "location": "input.txt.idx5",
                 "class": "File",
-                "basename": "input.txt.idx5",
-                "nameext": ".idx5",
-                "nameroot": "input.txt",
             }
         ],
         "size": 1111
@@ -392,11 +350,8 @@
     outfile:
       class: File
       checksum: sha1$327fc7aedf4f6b69a42a7c8b808dc5a7aff61376
-      path: fish.txt
+      location: fish.txt
       size: 1111
-      basename: fish.txt
-      nameext: .txt
-      nameroot: fish
   tool: draft-4/rename.cwl
   doc: |
     Test CreateFileRequirement with expression in filename.
@@ -411,13 +366,10 @@
 - job: draft-4/schemadef-job.json
   output:
     output:
-        path: output.txt
+        location: output.txt
         size: 12
         class: File
         checksum: "sha1$f12e6cfe70f3253f70b0dbde17c692e7fb0f1e5e"
-        basename: output.txt
-        nameext: .txt
-        nameroot: output
   tool: draft-4/schemadef-tool.cwl
   doc: |
     Test SchemaDefRequirement definition used in tool parameter
@@ -425,13 +377,10 @@
 - job: draft-4/schemadef-job.json
   output:
     output:
-        path: output.txt
+        location: output.txt
         size: 12
         class: File
         checksum: "sha1$f12e6cfe70f3253f70b0dbde17c692e7fb0f1e5e"
-        basename: output.txt
-        nameext: .txt
-        nameroot: output
   tool: draft-4/schemadef-wf.cwl
   doc: |
     Test SchemaDefRequirement definition used in workflow parameter
@@ -594,7 +543,7 @@
 - job: draft-4/formattest-job.json
   output:
     output:
-        "path": "output.txt"
+        "location": "output.txt"
         "format": "http://edamontology.org/format_2330"
         "size": 1111
         "class": "File"
@@ -606,7 +555,7 @@
 - job: draft-4/formattest2-job.json
   output:
     output:
-        "path": "output.txt"
+        "location": "output.txt"
         "format": "http://edamontology.org/format_1929"
         "size": 12010
         "class": "File"
@@ -618,7 +567,7 @@
 - job: draft-4/formattest2-job.json
   output:
     output:
-        "path": "output.txt"
+        "location": "output.txt"
         "format": "http://edamontology.org/format_1929"
         "size": 12010
         "class": "File"
@@ -632,13 +581,10 @@
   output:
     optional_file: null
     output_file:
-        path: output.txt
+        location: output.txt
         size: 13
         class: "File"
         checksum: "sha1$47a013e660d408619d894b20806b1d5086aab03b"
-        basename: output.txt
-        nameext: .txt
-        nameroot: output
   doc: |
     Test optional output file and optional secondaryFile on output.
 
@@ -661,13 +607,13 @@
   output:
     "orec": {
         "ofoo": {
-            "path": "foo",
+            "location": "foo",
             "size": 1111,
             "class": "File",
             "checksum": "sha1$327fc7aedf4f6b69a42a7c8b808dc5a7aff61376"
         },
         "obar": {
-            "path": "bar",
+            "location": "bar",
             "size": 12010,
             "class": "File",
             "checksum": "sha1$aeb3d11bdf536511649129f4077d5cda6a324118"
@@ -679,7 +625,7 @@
 - job: draft-4/empty.json
   output: {
     "foo": {
-        "path": "foo",
+        "location": "foo",
         "class": "File"
     }
   }
@@ -689,19 +635,19 @@
 - job: draft-4/abc.json
   output:
     files: [{
-        "path": "a",
+        "location": "a",
         "size": 0,
         "class": "File",
         "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709"
     },
     {
-        "path": "b",
+        "location": "b",
         "size": 0,
         "class": "File",
         "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709"
     },
     {
-        "path": "c",
+        "location": "c",
         "size": 0,
         "class": "File",
         "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709"
@@ -736,7 +682,7 @@
 - job: draft-4/conflict-job.json
   output: {
     "fileout": {
-        "path": "out.txt",
+        "location": "out.txt",
         "checksum": "sha1$a2d8d6e7b28295dc9977dc3bdb652ddd480995f0",
         "class": "File",
         "size": 25
@@ -749,7 +695,7 @@
   output:
     "outlist": {
         "size": 20,
-        "path": "output.txt",
+        "location": "output.txt",
         "checksum": "sha1$13cda8661796ae241da3a18668fb552161a72592",
         "class": "File"
     }
@@ -760,7 +706,7 @@
   output:
     "outlist": {
         "size": 20,
-        "path": "output.txt",
+        "location": "output.txt",
         "checksum": "sha1$13cda8661796ae241da3a18668fb552161a72592",
         "class": "File"
     }
@@ -776,14 +722,14 @@
                 "basename": "hello.txt",
                 "entry": {
                     "class": "File",
-                    "path": "hello.txt"
+                    "location": "hello.txt"
                 }
             },
             {
                 "basename": "goodbye.txt",
                 "entry": {
                     "class": "File",
-                    "path": "goodbye.txt"
+                    "location": "goodbye.txt"
                 }
             }
         ],

--- a/draft-4/conformance_test_draft-4.yaml
+++ b/draft-4/conformance_test_draft-4.yaml
@@ -738,13 +738,14 @@
   doc: Test directory input in Docker
 
 - job: draft-4/dir4-job.yml
-  output:
+  output: {
     "outlist": {
-        "size": 20,
+        "checksum": "sha1$2ab6f189e84753c05a23413fbf6b6fbf4c53489f",
+        "size": 90,
         "location": "output.txt",
-        "checksum": "sha1$13cda8661796ae241da3a18668fb552161a72592",
         "class": "File"
     }
+  }
   tool: draft-4/dir4.cwl
   doc: Test directories in secondaryFiles
 
@@ -752,9 +753,8 @@
   output: {
     "outlist": {
         "checksum": "sha1$907a866a3e0b7f1fc5a2222531c5fb9063704438",
-        "path": "/home/peter/work/common-workflow-language/draft-4/draft-4/output.txt",
         "size": 33,
-        "location": "file:///home/peter/work/common-workflow-language/draft-4/draft-4/output.txt",
+        "location": "output.txt",
         "class": "File"
     }
   }

--- a/draft-4/draft-4/binding-test.cwl
+++ b/draft-4/draft-4/binding-test.cwl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 
 inputs:
   - id: reference
@@ -19,7 +19,7 @@ inputs:
     type: File
     default:
       class: File
-      path: args.py
+      location: args.py
     inputBinding:
       position: -1
 

--- a/draft-4/draft-4/bwa-mem-job.json
+++ b/draft-4/draft-4/bwa-mem-job.json
@@ -1,18 +1,18 @@
 {
     "reference": {
         "class": "File",
-        "path": "chr20.fa",
+        "location": "chr20.fa",
         "size": 123,
         "checksum": "sha1$hash"
     },
     "reads": [
         {
             "class": "File",
-            "path": "example_human_Illumina.pe_1.fastq"
+            "location": "example_human_Illumina.pe_1.fastq"
         },
         {
             "class": "File",
-            "path": "example_human_Illumina.pe_2.fastq"
+            "location": "example_human_Illumina.pe_2.fastq"
         }
     ],
     "min_std_max_min": [

--- a/draft-4/draft-4/bwa-mem-tool.cwl
+++ b/draft-4/draft-4/bwa-mem-tool.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: draft-4.dev2
+cwlVersion: draft-4.dev3
 
 class: CommandLineTool
 
@@ -34,7 +34,7 @@ inputs:
     type: File
     default:
       class: File
-      path: args.py
+      location: args.py
     inputBinding:
       position: -1
 

--- a/draft-4/draft-4/cat-job.json
+++ b/draft-4/draft-4/cat-job.json
@@ -1,6 +1,6 @@
 {
     "file1": {
         "class": "File",
-        "path": "hello.txt"
+        "location": "hello.txt"
     }
 }

--- a/draft-4/draft-4/cat-n-job.json
+++ b/draft-4/draft-4/cat-n-job.json
@@ -1,7 +1,7 @@
 {
     "file1": {
         "class": "File",
-        "path": "hello.txt"
+        "location": "hello.txt"
     },
     "numbering": true
 }

--- a/draft-4/draft-4/cat1-testcli.cwl
+++ b/draft-4/draft-4/cat1-testcli.cwl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 {
     "class": "CommandLineTool",
-    "cwlVersion": "cwl:draft-4.dev2",
+    "cwlVersion": "cwl:draft-4.dev3",
     "description": "Print the contents of a file to stdout using 'cat' running in a docker container.",
     "inputs": [
         {
@@ -22,7 +22,7 @@
         type: File,
         default: {
           class: File,
-          path: args.py
+          location: args.py
         },
         inputBinding: {
           position: -1

--- a/draft-4/draft-4/cat1-tool.cwl
+++ b/draft-4/draft-4/cat1-tool.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 class: CommandLineTool
 description: "Print the contents of a file to stdout using 'cat' running in a docker container."
 hints:

--- a/draft-4/draft-4/cat2-tool.cwl
+++ b/draft-4/draft-4/cat2-tool.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 description: "Print the contents of a file to stdout using 'cat' running in a docker container."
 hints:
   DockerRequirement:

--- a/draft-4/draft-4/cat3-tool-mediumcut.cwl
+++ b/draft-4/draft-4/cat3-tool-mediumcut.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 description: "Print the contents of a file to stdout using 'cat' running in a docker container."
 hints:
   DockerRequirement:

--- a/draft-4/draft-4/cat3-tool-shortcut.cwl
+++ b/draft-4/draft-4/cat3-tool-shortcut.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 description: "Print the contents of a file to stdout using 'cat' running in a docker container."
 hints:
   DockerRequirement:

--- a/draft-4/draft-4/cat3-tool.cwl
+++ b/draft-4/draft-4/cat3-tool.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 description: "Print the contents of a file to stdout using 'cat' running in a docker container."
 hints:
   DockerRequirement:

--- a/draft-4/draft-4/cat4-tool.cwl
+++ b/draft-4/draft-4/cat4-tool.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 description: "Print the contents of a file to stdout using 'cat' running in a docker container."
 hints:
   DockerRequirement:

--- a/draft-4/draft-4/cat5-tool.cwl
+++ b/draft-4/draft-4/cat5-tool.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 class: CommandLineTool
 description: "Print the contents of a file to stdout using 'cat' running in a docker container."
 hints:

--- a/draft-4/draft-4/conflict-wf.cwl
+++ b/draft-4/draft-4/conflict-wf.cwl
@@ -1,4 +1,4 @@
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 $graph:
 - id: echo
   class: CommandLineTool

--- a/draft-4/draft-4/count-lines1-wf.cwl
+++ b/draft-4/draft-4/count-lines1-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 
 inputs:
   file1:

--- a/draft-4/draft-4/count-lines2-wf.cwl
+++ b/draft-4/draft-4/count-lines2-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 requirements:
   InlineJavascriptRequirement: {}
 

--- a/draft-4/draft-4/count-lines3-job.json
+++ b/draft-4/draft-4/count-lines3-job.json
@@ -2,11 +2,11 @@
     "file1": [
         {
             "class": "File",
-            "path": "whale.txt"
+            "location": "whale.txt"
         },
         {
             "class": "File",
-            "path": "hello.txt"
+            "location": "hello.txt"
         }
     ]
 }

--- a/draft-4/draft-4/count-lines3-wf.cwl
+++ b/draft-4/draft-4/count-lines3-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 
 inputs:
     file1:

--- a/draft-4/draft-4/count-lines4-job.json
+++ b/draft-4/draft-4/count-lines4-job.json
@@ -1,10 +1,10 @@
 {
     "file1": {
         "class": "File",
-        "path": "whale.txt"
+        "location": "whale.txt"
     },
     "file2": {
         "class": "File",
-        "path": "hello.txt"
+        "location": "hello.txt"
     }
 }

--- a/draft-4/draft-4/count-lines4-wf.cwl
+++ b/draft-4/draft-4/count-lines4-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 
 inputs:
     file1:

--- a/draft-4/draft-4/count-lines5-wf.cwl
+++ b/draft-4/draft-4/count-lines5-wf.cwl
@@ -1,11 +1,11 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 
 inputs:
     file1:
       type: File
-      default: {class: File, path: hello.txt}
+      default: {class: File, location: hello.txt}
 outputs:
     count_output:
       type: int

--- a/draft-4/draft-4/count-lines6-job.json
+++ b/draft-4/draft-4/count-lines6-job.json
@@ -2,21 +2,21 @@
     "file1": [
         {
             "class": "File",
-            "path": "whale.txt"
+            "location": "whale.txt"
         },
         {
             "class": "File",
-            "path": "whale.txt"
+            "location": "whale.txt"
         }
     ],
     "file2": [
         {
             "class": "File",
-            "path": "hello.txt"
+            "location": "hello.txt"
         },
         {
             "class": "File",
-            "path": "hello.txt"
+            "location": "hello.txt"
         }
     ]
 }

--- a/draft-4/draft-4/count-lines6-wf.cwl
+++ b/draft-4/draft-4/count-lines6-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 
 inputs:
     file1: File[]

--- a/draft-4/draft-4/count-lines7-wf.cwl
+++ b/draft-4/draft-4/count-lines7-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 
 requirements:
   - class: MultipleInputFeatureRequirement

--- a/draft-4/draft-4/count-lines8-wf.cwl
+++ b/draft-4/draft-4/count-lines8-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 
 inputs:
     file1: File

--- a/draft-4/draft-4/count-lines9-wf.cwl
+++ b/draft-4/draft-4/count-lines9-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 
 inputs: []
 
@@ -16,7 +16,7 @@ steps:
       file1:
         default:
           class: File
-          path: whale.txt
+          location: whale.txt
     out: [output]
 
   step2:

--- a/draft-4/draft-4/dir-job.yml
+++ b/draft-4/draft-4/dir-job.yml
@@ -1,3 +1,3 @@
 indir:
   class: Directory
-  path: testdir
+  location: testdir

--- a/draft-4/draft-4/dir-job.yml
+++ b/draft-4/draft-4/dir-job.yml
@@ -1,0 +1,3 @@
+indir:
+  class: Directory
+  path: testdir

--- a/draft-4/draft-4/dir.cwl
+++ b/draft-4/draft-4/dir.cwl
@@ -1,0 +1,18 @@
+class: CommandLineTool
+cwlVersion: draft-4.dev2
+requirements:
+  - class: ShellCommandRequirement
+inputs:
+  indir: Directory
+outputs:
+  outlist:
+    type: File
+    outputBinding:
+      glob: output.txt
+baseCommand: []
+arguments: ["cd", "$(inputs.indir.path)",
+  {shellQuote: false, valueFrom: "&&"},
+  "find", ".",
+  {shellQuote: false, valueFrom: "|"},
+  "sort"]
+stdout: output.txt

--- a/draft-4/draft-4/dir.cwl
+++ b/draft-4/draft-4/dir.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: draft-4.dev2
+cwlVersion: draft-4.dev3
 requirements:
   - class: ShellCommandRequirement
 inputs:

--- a/draft-4/draft-4/dir2.cwl
+++ b/draft-4/draft-4/dir2.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: draft-4.dev2
+cwlVersion: draft-4.dev3
 hints:
   DockerRequirement:
     dockerPull: debian:8

--- a/draft-4/draft-4/dir2.cwl
+++ b/draft-4/draft-4/dir2.cwl
@@ -1,0 +1,20 @@
+class: CommandLineTool
+cwlVersion: draft-4.dev2
+hints:
+  DockerRequirement:
+    dockerPull: debian:8
+  ShellCommandRequirement: {}
+inputs:
+  indir: Directory
+outputs:
+  outlist:
+    type: File
+    outputBinding:
+      glob: output.txt
+baseCommand: []
+arguments: ["cd", "$(inputs.indir.path)",
+  {shellQuote: false, valueFrom: "&&"},
+  "find", ".",
+  {shellQuote: false, valueFrom: "|"},
+  "sort"]
+stdout: output.txt

--- a/draft-4/draft-4/dir3-job.yml
+++ b/draft-4/draft-4/dir3-job.yml
@@ -1,3 +1,3 @@
 inf:
   class: File
-  path: hello.tar
+  location: hello.tar

--- a/draft-4/draft-4/dir3-job.yml
+++ b/draft-4/draft-4/dir3-job.yml
@@ -1,0 +1,3 @@
+inf:
+  class: File
+  path: hello.tar

--- a/draft-4/draft-4/dir3.cwl
+++ b/draft-4/draft-4/dir3.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: draft-4.dev2
+cwlVersion: draft-4.dev3
 baseCommand: [tar, xvf]
 inputs:
   inf:

--- a/draft-4/draft-4/dir3.cwl
+++ b/draft-4/draft-4/dir3.cwl
@@ -1,0 +1,13 @@
+class: CommandLineTool
+cwlVersion: draft-4.dev2
+baseCommand: [tar, xvf]
+inputs:
+  inf:
+    type: File
+    inputBinding:
+      position: 1
+outputs:
+  outdir:
+    type: Directory
+    outputBinding:
+      glob: .

--- a/draft-4/draft-4/dir4-job.yml
+++ b/draft-4/draft-4/dir4-job.yml
@@ -1,0 +1,10 @@
+inf:
+  class: File
+  location: hello.tar
+  secondaryFiles:
+    - class: File
+      location: index.py
+    - entryname: testdir
+      entry:
+        class: Directory
+        location: testdir

--- a/draft-4/draft-4/dir4-job.yml
+++ b/draft-4/draft-4/dir4-job.yml
@@ -4,7 +4,7 @@ inf:
   secondaryFiles:
     - class: File
       location: index.py
-    - entryname: testdir
+    - entryname: xtestdir
       entry:
         class: Directory
         location: testdir

--- a/draft-4/draft-4/dir4.cwl
+++ b/draft-4/draft-4/dir4.cwl
@@ -1,0 +1,18 @@
+class: CommandLineTool
+cwlVersion: draft-4.dev3
+requirements:
+  - class: ShellCommandRequirement
+inputs:
+  inf: File
+outputs:
+  outlist:
+    type: File
+    outputBinding:
+      glob: output.txt
+baseCommand: []
+arguments: ["cd", "$(inputs.inf.dirname)",
+  {shellQuote: false, valueFrom: "&&"},
+  "find", ".",
+  {shellQuote: false, valueFrom: "|"},
+  "sort"]
+stdout: output.txt

--- a/draft-4/draft-4/dir5.cwl
+++ b/draft-4/draft-4/dir5.cwl
@@ -1,0 +1,18 @@
+class: CommandLineTool
+cwlVersion: draft-4.dev3
+requirements:
+  - class: ShellCommandRequirement
+  - class: InitialWorkDirRequirement
+    listing: $(inputs.indir.listing)
+inputs:
+  indir: Directory
+outputs:
+  outlist:
+    type: File
+    outputBinding:
+      glob: output.txt
+baseCommand: []
+arguments: ["find", ".",
+  {shellQuote: false, valueFrom: "|"},
+  "sort"]
+stdout: output.txt

--- a/draft-4/draft-4/echo-tool.cwl
+++ b/draft-4/draft-4/echo-tool.cwl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 inputs:
   in:
     type: Any

--- a/draft-4/draft-4/egrep-stderr-mediumcut.cwl
+++ b/draft-4/draft-4/egrep-stderr-mediumcut.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 description: "Test of capturing stderr output in a docker container."
 hints:
   DockerRequirement:

--- a/draft-4/draft-4/egrep-stderr-shortcut.cwl
+++ b/draft-4/draft-4/egrep-stderr-shortcut.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 description: "Test of capturing stderr output in a docker container."
 hints:
   DockerRequirement:

--- a/draft-4/draft-4/egrep-stderr.cwl
+++ b/draft-4/draft-4/egrep-stderr.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 description: "Test of capturing stderr output in a docker container."
 hints:
   DockerRequirement:

--- a/draft-4/draft-4/env-tool1.cwl
+++ b/draft-4/draft-4/env-tool1.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 inputs:
   in: string
 outputs:

--- a/draft-4/draft-4/env-tool2.cwl
+++ b/draft-4/draft-4/env-tool2.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 inputs:
   in: string
 outputs:

--- a/draft-4/draft-4/env-wf1.cwl
+++ b/draft-4/draft-4/env-wf1.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 
 inputs:
     in: string

--- a/draft-4/draft-4/env-wf2.cwl
+++ b/draft-4/draft-4/env-wf2.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 
 inputs:
     in: string

--- a/draft-4/draft-4/formattest-job.json
+++ b/draft-4/draft-4/formattest-job.json
@@ -1,7 +1,7 @@
 {
     "input": {
         "class": "File",
-        "path": "whale.txt",
+        "location": "whale.txt",
         "format": "edam:format_2330"
     }
 }

--- a/draft-4/draft-4/formattest.cwl
+++ b/draft-4/draft-4/formattest.cwl
@@ -1,6 +1,6 @@
 $namespaces:
   edam: "http://edamontology.org/"
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 class: CommandLineTool
 description: "Reverse each line using the `rev` command"
 inputs:

--- a/draft-4/draft-4/formattest2-job.json
+++ b/draft-4/draft-4/formattest2-job.json
@@ -1,7 +1,7 @@
 {
     "input": {
         "class": "File",
-        "path": "ref.fasta",
+        "location": "ref.fasta",
         "format": "edam:format_1929"
     }
 }

--- a/draft-4/draft-4/formattest2.cwl
+++ b/draft-4/draft-4/formattest2.cwl
@@ -3,7 +3,7 @@ $namespaces:
 $schemas:
   - EDAM.owl
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 description: "Reverse each line using the `rev` command"
 
 inputs:

--- a/draft-4/draft-4/formattest3.cwl
+++ b/draft-4/draft-4/formattest3.cwl
@@ -5,7 +5,7 @@ $schemas:
   - EDAM.owl
   - gx_edam.ttl
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 description: "Reverse each line using the `rev` command"
 
 inputs:

--- a/draft-4/draft-4/glob-expr-list.cwl
+++ b/draft-4/draft-4/glob-expr-list.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 
 inputs:
   ids:

--- a/draft-4/draft-4/metadata.cwl
+++ b/draft-4/draft-4/metadata.cwl
@@ -6,7 +6,7 @@ $schemas:
   - foaf.rdf
   - dcterms.rdf
 
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 class: CommandLineTool
 description: "Print the contents of a file to stdout using 'cat' running in a docker container."
 

--- a/draft-4/draft-4/null-expression1-tool.cwl
+++ b/draft-4/draft-4/null-expression1-tool.cwl
@@ -3,7 +3,7 @@
 class: ExpressionTool
 requirements:
   - class: InlineJavascriptRequirement
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 
 inputs:
   i1:

--- a/draft-4/draft-4/null-expression2-tool.cwl
+++ b/draft-4/draft-4/null-expression2-tool.cwl
@@ -3,7 +3,7 @@
 class: ExpressionTool
 requirements:
   - class: InlineJavascriptRequirement
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 
 inputs:
   i1: Any

--- a/draft-4/draft-4/optional-output.cwl
+++ b/draft-4/draft-4/optional-output.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: "cwl:draft-4.dev2"
+cwlVersion: "cwl:draft-4.dev3"
 description: "Print the contents of a file to stdout using 'cat' running in a docker container."
 hints:
   DockerRequirement:

--- a/draft-4/draft-4/params.cwl
+++ b/draft-4/draft-4/params.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 inputs:
   bar:
     type: Any

--- a/draft-4/draft-4/params2.cwl
+++ b/draft-4/draft-4/params2.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 requirements:
   - class: InlineJavascriptRequirement
 

--- a/draft-4/draft-4/parseInt-job.json
+++ b/draft-4/draft-4/parseInt-job.json
@@ -1,6 +1,6 @@
 {
     "file1": {
         "class": "File",
-        "path": "number.txt"
+        "location": "number.txt"
     }
 }

--- a/draft-4/draft-4/parseInt-tool.cwl
+++ b/draft-4/draft-4/parseInt-tool.cwl
@@ -3,7 +3,7 @@
 class: ExpressionTool
 requirements:
   - class: InlineJavascriptRequirement
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 
 inputs:
   file1:

--- a/draft-4/draft-4/record-output-job.json
+++ b/draft-4/draft-4/record-output-job.json
@@ -1,6 +1,6 @@
 {
   "irec": {
-    "ifoo": {"path": "whale.txt", "class": "File"},
-    "ibar": {"path": "ref.fasta", "class": "File"}
+    "ifoo": {"location": "whale.txt", "class": "File"},
+    "ibar": {"location": "ref.fasta", "class": "File"}
   }
 }

--- a/draft-4/draft-4/record-output.cwl
+++ b/draft-4/draft-4/record-output.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 requirements:
   - class: ShellCommandRequirement
 inputs:

--- a/draft-4/draft-4/rename-job.json
+++ b/draft-4/draft-4/rename-job.json
@@ -1,6 +1,6 @@
 {
     "srcfile": {
-        "path": "whale.txt",
+        "location": "whale.txt",
         "class": "File"
     },
     "newname": "fish.txt"

--- a/draft-4/draft-4/rename.cwl
+++ b/draft-4/draft-4/rename.cwl
@@ -3,9 +3,9 @@ cwlVersion: cwl:draft-4.dev3
 baseCommand: "true"
 requirements:
   CreateFileRequirement:
-    fileDef:
-      - filename: $(inputs.newname)
-        fileContent: $(inputs.srcfile)
+    listing:
+      - entryname: $(inputs.newname)
+        entry: $(inputs.srcfile)
 inputs:
   srcfile: File
   newname: string

--- a/draft-4/draft-4/rename.cwl
+++ b/draft-4/draft-4/rename.cwl
@@ -2,7 +2,7 @@ class: CommandLineTool
 cwlVersion: cwl:draft-4.dev3
 baseCommand: "true"
 requirements:
-  CreateFileRequirement:
+  InitialWorkDirRequirement:
     listing:
       - entryname: $(inputs.newname)
         entry: $(inputs.srcfile)

--- a/draft-4/draft-4/rename.cwl
+++ b/draft-4/draft-4/rename.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 baseCommand: "true"
 requirements:
   CreateFileRequirement:

--- a/draft-4/draft-4/revsort-job.json
+++ b/draft-4/draft-4/revsort-job.json
@@ -1,6 +1,6 @@
 {
   "input": {
     "class": "File",
-    "path": "whale.txt"
+    "location": "whale.txt"
   }
 }

--- a/draft-4/draft-4/revsort.cwl
+++ b/draft-4/draft-4/revsort.cwl
@@ -3,7 +3,7 @@
 #
 class: Workflow
 description: "Reverse the lines in a document, then sort those lines."
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 
 # Requirements & hints specify prerequisites and extensions to the workflow.
 # In this example, DockerRequirement specifies a default Docker container

--- a/draft-4/draft-4/revtool.cwl
+++ b/draft-4/draft-4/revtool.cwl
@@ -2,7 +2,7 @@
 # Simplest example command line program wrapper for the Unix tool "rev".
 #
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 description: "Reverse each line using the `rev` command"
 
 # The "inputs" array defines the structure of the input object that describes

--- a/draft-4/draft-4/scatter-valuefrom-wf1.cwl
+++ b/draft-4/draft-4/scatter-valuefrom-wf1.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 class: Workflow
 inputs:
   inp:

--- a/draft-4/draft-4/scatter-valuefrom-wf2.cwl
+++ b/draft-4/draft-4/scatter-valuefrom-wf2.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 class: Workflow
 
 inputs:

--- a/draft-4/draft-4/scatter-valuefrom-wf3.cwl
+++ b/draft-4/draft-4/scatter-valuefrom-wf3.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 $graph:
 
 - id: echo

--- a/draft-4/draft-4/scatter-valuefrom-wf4.cwl
+++ b/draft-4/draft-4/scatter-valuefrom-wf4.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 $graph:
 - id: echo
   class: CommandLineTool

--- a/draft-4/draft-4/scatter-wf1.cwl
+++ b/draft-4/draft-4/scatter-wf1.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 class: Workflow
 inputs:
   inp: string[]

--- a/draft-4/draft-4/scatter-wf2.cwl
+++ b/draft-4/draft-4/scatter-wf2.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 class: Workflow
 
 inputs:

--- a/draft-4/draft-4/scatter-wf3.cwl
+++ b/draft-4/draft-4/scatter-wf3.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 $graph:
 
 - id: echo

--- a/draft-4/draft-4/scatter-wf4.cwl
+++ b/draft-4/draft-4/scatter-wf4.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 $graph:
 - id: echo
   class: CommandLineTool

--- a/draft-4/draft-4/schemadef-tool.cwl
+++ b/draft-4/draft-4/schemadef-tool.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 requirements:
   - $import: schemadef-type.yml
   - class: InlineJavascriptRequirement

--- a/draft-4/draft-4/schemadef-wf.cwl
+++ b/draft-4/draft-4/schemadef-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 class: Workflow
 
 requirements:

--- a/draft-4/draft-4/search-job.json
+++ b/draft-4/draft-4/search-job.json
@@ -1,7 +1,7 @@
 {
     "infile": {
         "class": "File",
-        "path": "whale.txt"
+        "location": "whale.txt"
     },
     "term": "find"
 }

--- a/draft-4/draft-4/search.cwl
+++ b/draft-4/draft-4/search.cwl
@@ -7,10 +7,9 @@ $graph:
     - valueFrom: input.txt
       position: 1
   requirements:
-    - class: CreateFileRequirement
-      fileDef:
-        - filename: input.txt
-          fileContent: $(inputs.file)
+    - class: InitialWorkDirRequirement
+      listing:
+        input.txt: $(inputs.file)
     - class: InlineJavascriptRequirement
 
   inputs:

--- a/draft-4/draft-4/search.cwl
+++ b/draft-4/draft-4/search.cwl
@@ -1,4 +1,4 @@
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 $graph:
 - id: index
   class: CommandLineTool
@@ -19,7 +19,7 @@ $graph:
       type: File
       default:
         class: File
-        path: index.py
+        location: index.py
       inputBinding:
         position: 0
   outputs:
@@ -54,7 +54,7 @@ $graph:
       type: File
       default:
         class: File
-        path: search.py
+        location: search.py
       inputBinding:
         position: 0
     term:

--- a/draft-4/draft-4/search.cwl
+++ b/draft-4/draft-4/search.cwl
@@ -30,9 +30,9 @@ $graph:
       secondaryFiles:
         - ".idx1"
         - "^.idx2"
-        - '$(self.path+".idx3")'
-        - '$({"path": self.path+".idx4", "class": "File"})'
-        - '${ return self.path+".idx5"; }'
+        - '$(self.location+".idx3")'
+        - '$({"location": self.location+".idx4", "class": "File"})'
+        - '${ return self.location+".idx5"; }'
 
 - id: search
   class: CommandLineTool
@@ -47,9 +47,9 @@ $graph:
       secondaryFiles:
         - ".idx1"
         - "^.idx2"
-        - '$(self.path+".idx3")'
-        - '$({"path": self.path+".idx4", "class": "File"})'
-        - '${ return self.path+".idx5"; }'
+        - '$(self.location+".idx3")'
+        - '$({"location": self.location+".idx4", "class": "File"})'
+        - '${ return self.location+".idx5"; }'
     search.py:
       type: File
       default:

--- a/draft-4/draft-4/shelltest.cwl
+++ b/draft-4/draft-4/shelltest.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 description: "Reverse each line using the `rev` command then sort."
 requirements:
   - class: ShellCommandRequirement

--- a/draft-4/draft-4/sorttool.cwl
+++ b/draft-4/draft-4/sorttool.cwl
@@ -2,7 +2,7 @@
 # demonstrating command line flags.
 class: CommandLineTool
 description: "Sort lines using the `sort` command"
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 
 # This example is similar to the previous one, with an additional input
 # parameter called "reverse".  It is a boolean parameter, which is

--- a/draft-4/draft-4/stagefile-job.yml
+++ b/draft-4/draft-4/stagefile-job.yml
@@ -1,0 +1,3 @@
+infile:
+  class: File
+  location: whale.txt

--- a/draft-4/draft-4/stagefile.cwl
+++ b/draft-4/draft-4/stagefile.cwl
@@ -1,0 +1,17 @@
+class: CommandLineTool
+cwlVersion: draft-4.dev3
+requirements:
+  InitialWorkDirRequirement:
+    listing:
+      - entryname: $(inputs.infile.basename)
+        entry: $(inputs.infile)
+        writable: true
+inputs:
+  infile: File
+outputs:
+  outfile:
+    type: File
+    outputBinding:
+      glob: $(inputs.infile.basename)
+baseCommand: "sed"
+arguments: ["-i", "s/Ishmael/Bob/", $(inputs.infile.basename)]

--- a/draft-4/draft-4/step-valuefrom-wf.cwl
+++ b/draft-4/draft-4/step-valuefrom-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 requirements:
   - class: StepInputExpressionRequirement
 

--- a/draft-4/draft-4/step-valuefrom-wf.json
+++ b/draft-4/draft-4/step-valuefrom-wf.json
@@ -2,7 +2,7 @@
     "in": {
         "file1": {
             "class": "File",
-            "path": "whale.txt"
+            "location": "whale.txt"
         }
     }
 }

--- a/draft-4/draft-4/step-valuefrom2-wf.cwl
+++ b/draft-4/draft-4/step-valuefrom2-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 requirements:
   - class: StepInputExpressionRequirement
   - class: InlineJavascriptRequirement

--- a/draft-4/draft-4/step-valuefrom3-wf.cwl
+++ b/draft-4/draft-4/step-valuefrom3-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 requirements:
   - class: StepInputExpressionRequirement
   - class: InlineJavascriptRequirement

--- a/draft-4/draft-4/template-tool.cwl
+++ b/draft-4/draft-4/template-tool.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 class: CommandLineTool
 requirements:
   - class: DockerRequirement

--- a/draft-4/draft-4/template-tool.cwl
+++ b/draft-4/draft-4/template-tool.cwl
@@ -9,9 +9,8 @@ requirements:
       - { $include: underscore.js }
       - "var t = function(s) { return _.template(s)({'inputs': inputs}); };"
   - class: CreateFileRequirement
-    fileDef:
-      - filename: foo.txt
-        fileContent: >
+    listing:
+      foo.txt: >
           $(t("The file is <%= inputs.file1.path.split('/').slice(-1)[0] %>\n"))
 inputs:
   - id: file1

--- a/draft-4/draft-4/template-tool.cwl
+++ b/draft-4/draft-4/template-tool.cwl
@@ -8,7 +8,7 @@ requirements:
     expressionLib:
       - { $include: underscore.js }
       - "var t = function(s) { return _.template(s)({'inputs': inputs}); };"
-  - class: CreateFileRequirement
+  - class: InitialWorkDirRequirement
     listing:
       foo.txt: >
           $(t("The file is <%= inputs.file1.path.split('/').slice(-1)[0] %>\n"))

--- a/draft-4/draft-4/test-cwl-out.cwl
+++ b/draft-4/draft-4/test-cwl-out.cwl
@@ -1,5 +1,5 @@
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement

--- a/draft-4/draft-4/tmap-job.json
+++ b/draft-4/draft-4/tmap-job.json
@@ -1,7 +1,7 @@
 {
     "reads": {
         "class": "File",
-        "path": "reads.fastq"
+        "location": "reads.fastq"
     },
     "stages": [
         {

--- a/draft-4/draft-4/tmap-tool.cwl
+++ b/draft-4/draft-4/tmap-tool.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 {
-    "cwlVersion": "cwl:draft-4.dev2",
+    "cwlVersion": "cwl:draft-4.dev3",
 
     "class": "CommandLineTool",
 
@@ -24,7 +24,7 @@
         type: File,
         default: {
           class: File,
-          path: args.py
+          location: args.py
         },
         inputBinding: {
           position: -1

--- a/draft-4/draft-4/wc-job.json
+++ b/draft-4/draft-4/wc-job.json
@@ -1,6 +1,6 @@
 {
     "file1": {
         "class": "File",
-        "path": "whale.txt"
+        "location": "whale.txt"
     }
 }

--- a/draft-4/draft-4/wc-tool.cwl
+++ b/draft-4/draft-4/wc-tool.cwl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 
 inputs:
   file1: File

--- a/draft-4/draft-4/wc2-tool.cwl
+++ b/draft-4/draft-4/wc2-tool.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 requirements:
   - class: InlineJavascriptRequirement
 

--- a/draft-4/draft-4/wc3-tool.cwl
+++ b/draft-4/draft-4/wc3-tool.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 
 requirements:
   - class: InlineJavascriptRequirement

--- a/draft-4/draft-4/wc4-tool.cwl
+++ b/draft-4/draft-4/wc4-tool.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
-cwlVersion: cwl:draft-4.dev2
+cwlVersion: cwl:draft-4.dev3
 requirements:
   - class: InlineJavascriptRequirement
 


### PR DESCRIPTION
This adds the `Directory` type to the schema:

* `Directory` type consists of `location`, `path` and `listing` fields
* The `listing` is a list of `Dirent` objects which specify the name and the File object of each directory entry
* Files are now identified by the `location` field.  The `path` field is now reserved for CommandLineTool context only.
* Adds `dirname`, `basename`, `nameroot` and `nameext` fields for convenience of path manipulation in CommandLineTool. 
* Allow bare string list items in `arguments` to be evaluated as expressions
