### PR TITLE
Adjust conformance test for "writable" flag.

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -771,9 +771,9 @@
 - job: v1.0/stagefile-job.yml
   output: {
     "outfile": {
-        "checksum": "sha1$2d6c5e4430c4b200227cc77d3b0025082505ee19",
-        "size": 1107,
-        "location": "whale.txt",
+        "checksum": "sha1$b769c7b2e316edd4b5eb2d24799b2c1f9d8c86e6",
+        "size": 1111,
+        "location": "bob.txt",
         "class": "File"
     }
   }

--- a/v1.0/v1.0/stagefile.cwl
+++ b/v1.0/v1.0/stagefile.cwl
@@ -4,6 +4,7 @@ requirements:
   InitialWorkDirRequirement:
     listing:
       - entry: $(inputs.infile)
+        entryname: bob.txt
         writable: true
 inputs:
   infile: File
@@ -11,6 +12,12 @@ outputs:
   outfile:
     type: File
     outputBinding:
-      glob: $(inputs.infile.basename)
-baseCommand: "sed"
-arguments: ["-i", "s/Ishmael/Bob/", $(inputs.infile.basename)]
+      glob: bob.txt
+baseCommand: "python"
+arguments:
+  - "-c"
+  - |
+    f = open("bob.txt", "r+")
+    f.seek(8)
+    f.write("Bob.    ")
+    f.close()


### PR DESCRIPTION
Previous test did not test intended behavior because 'sed -i' doesn't modify the file in place.