### PR TITLE
Remove empty base command

### DIFF
--- a/v1.0/v1.0/dir.cwl
+++ b/v1.0/v1.0/dir.cwl
@@ -9,7 +9,6 @@ outputs:
     type: File
     outputBinding:
       glob: output.txt
-baseCommand: []
 arguments: ["cd", "$(inputs.indir.path)",
   {shellQuote: false, valueFrom: "&&"},
   "find", ".",

--- a/v1.0/v1.0/dir2.cwl
+++ b/v1.0/v1.0/dir2.cwl
@@ -11,7 +11,6 @@ outputs:
     type: File
     outputBinding:
       glob: output.txt
-baseCommand: []
 arguments: ["cd", "$(inputs.indir.path)",
   {shellQuote: false, valueFrom: "&&"},
   "find", ".",

--- a/v1.0/v1.0/dir4.cwl
+++ b/v1.0/v1.0/dir4.cwl
@@ -9,7 +9,6 @@ outputs:
     type: File
     outputBinding:
       glob: output.txt
-baseCommand: []
 arguments: ["cd", "$(inputs.inf.dirname)",
   {shellQuote: false, valueFrom: "&&"},
   "find", ".",

--- a/v1.0/v1.0/dir5.cwl
+++ b/v1.0/v1.0/dir5.cwl
@@ -11,7 +11,6 @@ outputs:
     type: File
     outputBinding:
       glob: output.txt
-baseCommand: []
 arguments: ["find", ".",
   {shellQuote: false, valueFrom: "|"},
   "sort"]

--- a/v1.0/v1.0/record-output.cwl
+++ b/v1.0/v1.0/record-output.cwl
@@ -30,7 +30,6 @@ outputs:
         type: File
         outputBinding:
           glob: bar
-baseCommand: []
 arguments:
   - {valueFrom: "cat", position: 1}
   - {valueFrom: "> foo", position: 3, shellQuote: false}

--- a/v1.0/v1.0/shelltest.cwl
+++ b/v1.0/v1.0/shelltest.cwl
@@ -12,7 +12,6 @@ outputs:
     outputBinding:
       glob: output.txt
 
-baseCommand: []
 arguments:
   - rev
   - {valueFrom: $(inputs.input)}

--- a/v1.0/v1.0/test-cwl-out.cwl
+++ b/v1.0/v1.0/test-cwl-out.cwl
@@ -11,7 +11,6 @@ outputs:
   - id: foo
     type: File
 
-baseCommand: []
 arguments:
    - valueFrom: >
        echo foo > foo && echo '{"foo": {"path": "$(runtime.outdir)/foo", "class": "File"} }' > cwl.output.json


### PR DESCRIPTION
Remove `baseCommand: []` from tests.  Merge after #265 is merged and imported schema in `cwltool` is updated.