### PR TITLE
Tests: move Docker from requirements to hints

### DIFF
--- a/v1.0/v1.0/template-tool.cwl
+++ b/v1.0/v1.0/template-tool.cwl
@@ -2,8 +2,6 @@
 cwlVersion: v1.0
 class: CommandLineTool
 requirements:
-  - class: DockerRequirement
-    dockerPull: "debian:8"
   - class: InlineJavascriptRequirement
     expressionLib:
       - { $include: underscore.js }
@@ -12,6 +10,9 @@ requirements:
     listing:
       - entryname: foo.txt
         entry: $(t("The file is <%= inputs.file1.path.split('/').slice(-1)[0] %>\n"))
+hints:
+  DockerRequirement:
+    dockerPull: "debian:8"
 inputs:
   - id: file1
     type: File

--- a/v1.0/v1.0/test-cwl-out.cwl
+++ b/v1.0/v1.0/test-cwl-out.cwl
@@ -2,8 +2,9 @@ class: CommandLineTool
 cwlVersion: v1.0
 requirements:
   - class: ShellCommandRequirement
-  - class: DockerRequirement
-    dockerPull: debian:wheezy
+hints:
+  DockerRequirement:
+    dockerPull: "debian:wheezy"
 
 inputs: []
 


### PR DESCRIPTION
Enables tests passing on Toil which explicitly checks for
DockerRequirement in requirements and presence of use-container. Matches
new recommendations for use of DockerRequirements when tools run without
Docker.

@mr-c @tetron This fixes some errors I ran into while trying to get Toil up to date with v1.0. Thanks for the review.