### PR TITLE
Move secondaryFiles, format and streamable to SchemaBase

### DIFF
--- a/v1.0/Process.yml
+++ b/v1.0/Process.yml
@@ -314,15 +314,6 @@ $graph:
       jsonldPredicate: "rdfs:label"
       doc: "A short, human-readable label of this object."
 
-
-- name: Parameter
-  type: record
-  extends: SchemaBase
-  abstract: true
-  doc: |
-    Define an input or output parameter to a process.
-
-  fields:
     - name: secondaryFiles
       type:
         - "null"
@@ -380,6 +371,15 @@ $graph:
         indicate whether it is valid to stream file contents using a named
         pipe.  Default: `false`.
 
+
+- name: Parameter
+  type: record
+  extends: SchemaBase
+  abstract: true
+  doc: |
+    Define an input or output parameter to a process.
+
+  fields:
     - name: doc
       type:
         - string?


### PR DESCRIPTION
As discussed on Gitter with @tetron, secondaryFiles, format and streamable should belong to SchemaBase so that they can be used for compound types. For example:

```
  bam:
    type:
      - 'null'
      - type: array
        items: File
        inputBinding:
          prefix: "--bam"
          position: 6
        secondaryFiles:
          - ".bai"
    doc: |
      A bam file of unknown type; Pilon will scan it and attempt to classify it as one
      of the above bam types.
```