### PR TITLE
Adding docker hint to conformance test workflow

### DIFF
--- a/v1.0/v1.0/bwa-mem-tool.cwl
+++ b/v1.0/v1.0/bwa-mem-tool.cwl
@@ -7,6 +7,8 @@ class: CommandLineTool
 hints:
   - class: ResourceRequirement
     coresMin: 4
+  - class: DockerRequirement
+    dockerPull: python
 
 inputs:
   - id: reference


### PR DESCRIPTION
Python wasn't install on the system the conformance test was being run on, so the hint for a python docker container was required to get the job to run.