### PR TITLE
fixing test in v1.0 and v1.1.0-dev1

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -63,7 +63,7 @@
     output_file:
       class: File
       checksum: sha1$47a013e660d408619d894b20806b1d5086aab03b
-      location:
+      location: Any
       size: 13
   doc: Test command execution in Docker with simplified syntax stdout redirection
 

--- a/v1.1.0-dev1/conformance_test_v1.1.0-dev1.yaml
+++ b/v1.1.0-dev1/conformance_test_v1.1.0-dev1.yaml
@@ -63,7 +63,7 @@
     output_file:
       class: File
       checksum: sha1$47a013e660d408619d894b20806b1d5086aab03b
-      location:
+      location: Any
       size: 13
   doc: Test command execution in Docker with simplified syntax stdout redirection
 


### PR DESCRIPTION
I've done some refactoring to cwltest code and this test started faiing for cwltool. As far as I can understand the code, this should actually accept any output name, but for some reason this test passes with current cwltest even with location left empty. If my understanding is correct and this indeed should be changed to Any, I'll also create a pull request for cwltest that cleanups some issues [discussed yesterday](https://github.com/common-workflow-language/cwltest/commit/3d1e2b8dd009096e3089c34ed01ef2ade53228c5#commitcomment-19269140)