### PR TITLE
Use v1.0 style id's in inputs/outputs example

### DIFF
--- a/v1.0/UserGuide.yml
+++ b/v1.0/UserGuide.yml
@@ -239,7 +239,7 @@
 
       ```
       outputs:
-        - id: example_out
+        example_out:
           type: File
           outputBinding:
             glob: hello.txt

--- a/v1.1.0-dev1/UserGuide.yml
+++ b/v1.1.0-dev1/UserGuide.yml
@@ -239,7 +239,7 @@
 
       ```
       outputs:
-        - id: example_out
+        example_out:
           type: File
           outputBinding:
             glob: hello.txt


### PR DESCRIPTION
Super minor issue, but just saw that the old `id` syntax was still in the v1.0 user guide. Also fixed it in the 1.1-dev1 folder, but I'm not sure if this will be valid 1.1 syntax. Thanks!