### PR TITLE
Add test of arguments containing shell directives 

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -999,3 +999,21 @@
   }
   tool: v1.0/shellchar.cwl
   doc: "Test that shell directives are not interpreted."
+
+- job: v1.0/empty.json
+  output: {
+    "stderr_file": {
+        "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709",
+        "location": Any,
+        "class": "File",
+        "size": 0
+    },
+    "stdout_file": {
+        "checksum": "sha1$1555252d52d4ec3262538a4426a83a99cfff4402",
+        "location": Any,
+        "class": "File",
+        "size": 9
+    }
+  }
+  tool: v1.0/shellchar2.cwl
+  doc: "Test that shell directives are quoted."

--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -981,3 +981,21 @@
       size: 15
   tool: v1.0/imported-hint.cwl
   doc: Test hints with $import
+
+- job: v1.0/empty.json
+  output: {
+    "stderr_file": {
+        "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709",
+        "location": Any,
+        "class": "File",
+        "size": 0
+    },
+    "stdout_file": {
+        "checksum": "sha1$1555252d52d4ec3262538a4426a83a99cfff4402",
+        "location": Any,
+        "class": "File",
+        "size": 9
+    }
+  }
+  tool: v1.0/shellchar.cwl
+  doc: "Test that shell directives are not interpreted."

--- a/v1.0/v1.0/shellchar.cwl
+++ b/v1.0/v1.0/shellchar.cwl
@@ -1,0 +1,13 @@
+#!/usr/bin/env cwl-runner
+class: CommandLineTool
+cwlVersion: v1.0
+doc: |
+  Ensure that arguments containing shell directives are not interpreted and
+  that `shellQuote: false` has no effect when ShellCommandRequirement is not in
+  effect.
+inputs: []
+outputs:
+  stdout_file: stdout
+  stderr_file: stderr
+baseCommand: echo
+arguments: [{valueFrom: "foo 1>&2", shellQuote: false}]

--- a/v1.0/v1.0/shellchar2.cwl
+++ b/v1.0/v1.0/shellchar2.cwl
@@ -1,0 +1,14 @@
+#!/usr/bin/env cwl-runner
+class: CommandLineTool
+cwlVersion: v1.0
+doc: |
+  Ensure that `shellQuote: true` is the default behavior when
+  ShellCommandRequirement is in effect.
+requirements:
+  ShellCommandRequirement: {}
+inputs: []
+outputs:
+  stdout_file: stdout
+  stderr_file: stderr
+baseCommand: echo
+arguments: ["foo 1>&2"]

--- a/v1.1.0-dev1/conformance_test_v1.1.0-dev1.yaml
+++ b/v1.1.0-dev1/conformance_test_v1.1.0-dev1.yaml
@@ -992,3 +992,21 @@
       size: 15
   tool: v1.1.0-dev1/imported-hint.cwl
   doc: Test hints with $import
+
+- job: v1.1.0-dev1/empty.json
+  output: {
+    "stderr_file": {
+        "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709",
+        "location": Any,
+        "class": "File",
+        "size": 0
+    },
+    "stdout_file": {
+        "checksum": "sha1$1555252d52d4ec3262538a4426a83a99cfff4402",
+        "location": Any,
+        "class": "File",
+        "size": 9
+    }
+  }
+  tool: v1.1.0-dev1/shellchar.cwl
+  doc: "Test that shell directives are not interpreted."

--- a/v1.1.0-dev1/conformance_test_v1.1.0-dev1.yaml
+++ b/v1.1.0-dev1/conformance_test_v1.1.0-dev1.yaml
@@ -1010,3 +1010,21 @@
   }
   tool: v1.1.0-dev1/shellchar.cwl
   doc: "Test that shell directives are not interpreted."
+
+- job: v1.1.0-dev1/empty.json
+  output: {
+    "stderr_file": {
+        "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709",
+        "location": Any,
+        "class": "File",
+        "size": 0
+    },
+    "stdout_file": {
+        "checksum": "sha1$1555252d52d4ec3262538a4426a83a99cfff4402",
+        "location": Any,
+        "class": "File",
+        "size": 9
+    }
+  }
+  tool: v1.1.0-dev1/shellchar2.cwl
+  doc: "Test that shell directives are quoted."

--- a/v1.1.0-dev1/v1.1.0-dev1/shellchar.cwl
+++ b/v1.1.0-dev1/v1.1.0-dev1/shellchar.cwl
@@ -1,0 +1,13 @@
+#!/usr/bin/env cwl-runner
+class: CommandLineTool
+cwlVersion: v1.1.0-dev1
+doc: |
+  Ensure that arguments containing shell directives are not interpreted and
+  that `shellQuote: false` has no effect when ShellCommandRequirement is not in
+  effect.
+inputs: []
+outputs:
+  stdout_file: stdout
+  stderr_file: stderr
+baseCommand: echo
+arguments: [{valueFrom: "foo 1>&2", shellQuote: false}]

--- a/v1.1.0-dev1/v1.1.0-dev1/shellchar2.cwl
+++ b/v1.1.0-dev1/v1.1.0-dev1/shellchar2.cwl
@@ -1,0 +1,14 @@
+#!/usr/bin/env cwl-runner
+class: CommandLineTool
+cwlVersion: v1.1.0-dev1
+doc: |
+  Ensure that `shellQuote: true` is the default behavior when
+  ShellCommandRequirement is in effect.
+requirements:
+  ShellCommandRequirement: {}
+inputs: []
+outputs:
+  stdout_file: stdout
+  stderr_file: stderr
+baseCommand: echo
+arguments: ["foo 1>&2"]


### PR DESCRIPTION
Add test to ensure that arguments containing shell directives are not interpreted and that `shellQuote: false` has no effect when ShellCommandRequirement is not in effect.