### PR TITLE
Remove superfluous resource requirement

### DIFF
--- a/v1.0/v1.0/bwa-mem-tool.cwl
+++ b/v1.0/v1.0/bwa-mem-tool.cwl
@@ -5,8 +5,6 @@ cwlVersion: v1.0
 class: CommandLineTool
 
 hints:
-  - class: ResourceRequirement
-    coresMin: 4
   - class: DockerRequirement
     dockerPull: python
 

--- a/v1.1.0-dev1/v1.1.0-dev1/bwa-mem-tool.cwl
+++ b/v1.1.0-dev1/v1.1.0-dev1/bwa-mem-tool.cwl
@@ -5,8 +5,6 @@ cwlVersion: v1.1.0-dev1
 class: CommandLineTool
 
 hints:
-  - class: ResourceRequirement
-    coresMin: 4
   - class: DockerRequirement
     dockerPull: python
 


### PR DESCRIPTION
"General test of command line generation" should not require a minimum of four cores.

Briefly discussed with @StarvingMarvin 