### PR TITLE
Add conformance test for nameroot and nameext

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -996,3 +996,20 @@
   job: v1.0/empty.json
   tool: v1.0/inline-js.cwl
   doc: Test InlineJavascriptRequirement with multiple expressions in the same tool
+
+- job: v1.0/basename-fields-job.yml
+  output:
+    extFile:
+      checksum: sha1$1334e67fe9eb70db8ae14ccfa6cfb59e2cc24eae
+      class: File
+      size: 4
+      location: Any
+      path: Any
+    rootFile:
+      checksum: sha1$b4a583c391e234cf210e1d576f68f674c8ad7ecd
+      class: File
+      size: 10
+      location: Any
+      path: Any
+  tool: ./v1.0/basename-fields-test.cwl
+  doc: Test that nameroot and nameext are generated from basename at execution time by the runner

--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -1000,9 +1000,9 @@
 - job: v1.0/basename-fields-job.yml
   output:
     extFile:
-      checksum: sha1$1334e67fe9eb70db8ae14ccfa6cfb59e2cc24eae
+      checksum: sha1$301a72c82a835e1737caf30f94d0eec210c4d9f1
       class: File
-      size: 4
+      size: 5
       location: Any
       path: Any
     rootFile:
@@ -1011,5 +1011,5 @@
       size: 10
       location: Any
       path: Any
-  tool: ./v1.0/basename-fields-test.cwl
+  tool: v1.0/basename-fields-test.cwl
   doc: Test that nameroot and nameext are generated from basename at execution time by the runner

--- a/v1.0/v1.0/basename-fields-job.yml
+++ b/v1.0/v1.0/basename-fields-job.yml
@@ -1,0 +1,5 @@
+cwlVersion: v1.0
+tool:
+  class: File
+  path: echo-tool.cwl
+

--- a/v1.0/v1.0/basename-fields-test.cwl
+++ b/v1.0/v1.0/basename-fields-test.cwl
@@ -1,0 +1,33 @@
+cwlVersion: v1.0
+class: Workflow
+
+requirements:
+  - class: StepInputExpressionRequirement
+
+inputs:
+  tool: File
+
+outputs:
+  rootFile:
+    type: File
+    outputSource: root/out
+  extFile:
+    type: File
+    outputSource: ext/out
+
+steps:
+  root:
+    run: echo-file-tool.cwl
+    in:
+      tool: tool
+      in:
+        valueFrom: $(inputs.tool.nameroot)
+    out: [out]
+  ext:
+    run: echo-file-tool.cwl
+    in:
+      tool: tool
+      in:
+        valueFrom: $(inputs.tool.nameext)
+    out: [out]
+

--- a/v1.0/v1.0/echo-file-tool.cwl
+++ b/v1.0/v1.0/echo-file-tool.cwl
@@ -1,0 +1,12 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [echo]
+inputs:
+  in:
+    type: string
+    inputBinding:
+      position: 1
+outputs:
+  out:
+    type: stdout
+


### PR DESCRIPTION
Right now cwltool doesn't generate nor nameroot nor nameext at execution time from basename of an input File.

In the specification it states that they should be, now we have a test for it!