### PR TITLE
Add conformance test for static_checker

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -981,3 +981,11 @@
       size: 15
   tool: v1.0/imported-hint.cwl
   doc: Test hints with $import
+
+- job: v1.0/count-lines6-job.json
+  output:
+    count_output: 34
+  tool: v1.0/count-lines11-wf.cwl
+  doc: |
+    Test single step workflow with Scatter step and two data links connected to
+    same input, flattened merge behavior. Workflow inputs are set as list

--- a/v1.0/v1.0/count-lines11-wf.cwl
+++ b/v1.0/v1.0/count-lines11-wf.cwl
@@ -1,0 +1,28 @@
+#!/usr/bin/env cwl-runner
+class: Workflow
+cwlVersion: v1.0
+
+requirements:
+  - class: MultipleInputFeatureRequirement
+
+inputs:
+    file1:
+      - type: array
+        items: File
+    file2:
+      - type: array
+        items: File
+
+outputs:
+    count_output:
+      type: int
+      outputSource: step1/output
+
+steps:
+  step1:
+    run: wc3-tool.cwl
+    in:
+      file1:
+        source: [file1, file2]
+        linkMerge: merge_flattened
+    out: [output]


### PR DESCRIPTION
Added `count-lines11-wf.cwl`

## Expected Behavior 
Workflow input
```json
file1:
  type:
    - type: array
      item: File
```
should be exactly the same as
```json
file1:
  type: File[]
```
## Actual Behavior
`static_checker` mistakenly fails with source -> sink mismatch
```
Tool definition failed validation:
count-lines11-wf.cwl:9:5: Source 'file1' of type [{"type": "array", "items": "File"}] is incompatible
count-lines11-wf.cwl:25:7:   with sink 'file1' of type {"type": "array", "items": "File"}
count-lines11-wf.cwl:25:7:   sink has linkMerge method merge_flattened
```
## Your Environment
* cwltool version: 1.0.20170622090721