### PR TITLE
adding git attributes file to keep LF line endings for correct sha on windows system instead of CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.txt text eol=lf
+*.fastq text eol=lf
+*.fai text eol=lf


### PR DESCRIPTION
On git clone on windows line endings changes from LF to CRLF but some of these files are used for Sha matching. On windows this causes problem as an additional `CR` char is introduced causing SHA to fail. Thus stating in gitattribute file to not change Line ending on such files.