### PR TITLE
Container correction: Adding missing Docker container in conformance tests

### DIFF
--- a/v1.0/v1.0/binding-test.cwl
+++ b/v1.0/v1.0/binding-test.cwl
@@ -2,7 +2,9 @@
 
 class: CommandLineTool
 cwlVersion: v1.0
-
+hints:
+  - class: DockerRequirement
+    dockerPull: python:2-slim
 inputs:
   - id: reference
     type: File

--- a/v1.0/v1.0/cat1-testcli.cwl
+++ b/v1.0/v1.0/cat1-testcli.cwl
@@ -3,6 +3,12 @@
     "class": "CommandLineTool",
     "cwlVersion": "v1.0",
     "doc": "Print the contents of a file to stdout using 'cat' running in a docker container.",
+    "hints": [
+        {
+            "class": "DockerRequirement",
+            "dockerPull": "python:2-slim"
+        }
+    ],
     "inputs": [
         {
             "id": "file1",

--- a/v1.0/v1.0/search.cwl
+++ b/v1.0/v1.0/search.cwl
@@ -2,7 +2,7 @@ cwlVersion: v1.0
 $graph:
 - id: index
   class: CommandLineTool
-  baseCommand: python2
+  baseCommand: python
   arguments:
     - valueFrom: input.txt
       position: 1
@@ -12,6 +12,9 @@ $graph:
         - entryname: input.txt
           entry: $(inputs.file)
     - class: InlineJavascriptRequirement
+  hints:
+    - class: DockerRequirement
+      dockerPull: python:2-slim
 
   inputs:
     file:  File
@@ -36,9 +39,12 @@ $graph:
 
 - id: search
   class: CommandLineTool
-  baseCommand: python2
+  baseCommand: python
   requirements:
     - class: InlineJavascriptRequirement
+  hints:
+    - class: DockerRequirement
+      dockerPull: python:2-slim
   inputs:
     file:
       type: File

--- a/v1.0/v1.0/stagefile.cwl
+++ b/v1.0/v1.0/stagefile.cwl
@@ -1,5 +1,8 @@
 class: CommandLineTool
 cwlVersion: v1.0
+hints:
+  - class: DockerRequirement
+    dockerPull: python:2-slim
 requirements:
   InitialWorkDirRequirement:
     listing:

--- a/v1.0/v1.0/tmap-tool.cwl
+++ b/v1.0/v1.0/tmap-tool.cwl
@@ -3,7 +3,12 @@
     "cwlVersion": "v1.0",
 
     "class": "CommandLineTool",
-
+    "hints": [
+        {
+            "class": "DockerRequirement",
+            "dockerPull": "python:2-slim"
+        }
+    ],
     "inputs": [
         {
             "id": "reads",


### PR DESCRIPTION
Some of the workflows/tools in conformance tests use utilities like python, bash. Currently assumes that they would be available by default on running machine. But as we are adding support for windows in which we would run these workflows in a docker container, we need to provide these containers.