### PR TITLE
adding .fasta file to gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.txt text eol=lf
 *.fastq text eol=lf
 *.fai text eol=lf
+*.fasta text eol=lf


### PR DESCRIPTION
adding `.fasta` extension in gitattributes. After git cloning with this change all conformance tests have passed on windows. 😄 