### PR TITLE
Container correction: adding docker containers as hints

### DIFF
--- a/v1.0/v1.0/formattest2.cwl
+++ b/v1.0/v1.0/formattest2.cwl
@@ -5,6 +5,9 @@ $schemas:
 class: CommandLineTool
 cwlVersion: v1.0
 doc: "Reverse each line using the `rev` command"
+hints:
+  DockerRequirement:
+    dockerPull: "debian:wheezy"
 
 inputs:
   input:

--- a/v1.0/v1.0/formattest3.cwl
+++ b/v1.0/v1.0/formattest3.cwl
@@ -7,6 +7,9 @@ $schemas:
 class: CommandLineTool
 cwlVersion: v1.0
 doc: "Reverse each line using the `rev` command"
+hints:
+  DockerRequirement:
+    dockerPull: "debian:wheezy"
 
 inputs:
   input:


### PR DESCRIPTION
These conformance tests uses `rev` to reverse, this command is not posix compliant. Therefore on default alpine container on windows it behaves differently then on ubuntu/debian image. Therefore adding `debian :wheezy` docker container as hints
 