### PR TITLE
Add test that names are preserved with reverse mapping of output.  Al…

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -286,6 +286,12 @@
   tool: "v1.0/scatter-wf4.cwl#main"
   doc: Test workflow scatter with two empty scatter parameters and dotproduct join method
 
+- job: v1.0/scatter-job1.json
+  output:
+    out: ["foo one", "foo two", "foo three", "foo four"]
+  tool: v1.0/scatter-wf5.cwl
+  doc: Test workflow scatter with step out as array of objects
+
 - tool: v1.0/echo-tool.cwl
   job: v1.0/env-job.json
   output:
@@ -754,6 +760,12 @@
   doc: |
     Test support for reading cwl.output.json when running in a Docker container
     and just 'location' is provided.
+
+- job: v1.0/empty.json
+  output: {}
+  tool: v1.0/test-cwl-out-wf.cwl
+  doc: |
+    Test support for reading cwl.output.json in a workflow.
 
 - job: v1.0/abc.json
   output:

--- a/v1.0/v1.0/checkname.cwl
+++ b/v1.0/v1.0/checkname.cwl
@@ -1,0 +1,7 @@
+cwlVersion: v1.0
+class: CommandLineTool
+inputs:
+  file1: File
+  expect: string
+outputs: []
+arguments: [test, '$(inputs.file1.path)', '=', '$(inputs.file1.dirname)/$(inputs.expect)']

--- a/v1.0/v1.0/scatter-wf5.cwl
+++ b/v1.0/v1.0/scatter-wf5.cwl
@@ -1,0 +1,38 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: Workflow
+inputs:
+  inp: string[]
+outputs:
+  out:
+    type: string[]
+    outputSource: step1/echo_out
+
+requirements:
+  - class: ScatterFeatureRequirement
+
+steps:
+  step1:
+    in:
+      echo_in: inp
+    out:
+      - id: echo_out
+    scatter: echo_in
+    run:
+      class: CommandLineTool
+      inputs:
+        echo_in:
+          type: string
+          inputBinding: {}
+      outputs:
+        echo_out:
+          type: string
+          outputBinding:
+            glob: "step1_out"
+            loadContents: true
+            outputEval: $(self[0].contents)
+      baseCommand: "echo"
+      arguments:
+        - "-n"
+        - "foo"
+      stdout: "step1_out"

--- a/v1.0/v1.0/test-cwl-out-wf.cwl
+++ b/v1.0/v1.0/test-cwl-out-wf.cwl
@@ -1,0 +1,19 @@
+class: Workflow
+cwlVersion: v1.0
+inputs: []
+outputs: []
+steps:
+  step1:
+    in:
+      file1:
+        default:
+          class: File
+          location: hello.txt
+    out: [foo]
+    run: test-cwl-out4.cwl
+  step2:
+    in:
+      file1: step1/foo
+      expect: {default: hello.txt}
+    out: []
+    run: checkname.cwl


### PR DESCRIPTION
…so test

that objects with 'id' field are legal in the 'out' of a workflow step.