### PR TITLE
Test file literal as input without Docker

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -1267,3 +1267,14 @@
             "size": 16
         }
     ]
+
+- job: v1.0/file-literal.yml
+  output:
+    output_file:
+      class: File
+      checksum: sha1$d0e04ff6c413c7d57f9a0ca0a33cd3ab52e2dd9c
+      location: output.txt
+      size: 18
+  tool: v1.0/cat3-nodocker.cwl
+  doc: Test file literal as input without Docker
+

--- a/v1.0/v1.0/cat3-nodocker.cwl
+++ b/v1.0/v1.0/cat3-nodocker.cwl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
 cwlVersion: v1.0
-doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
+doc: "Print the contents of a file to stdout using 'cat'."
 inputs:
   file1:
     type: File

--- a/v1.0/v1.0/cat3-nodocker.cwl
+++ b/v1.0/v1.0/cat3-nodocker.cwl
@@ -1,0 +1,16 @@
+#!/usr/bin/env cwl-runner
+class: CommandLineTool
+cwlVersion: v1.0
+doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
+inputs:
+  file1:
+    type: File
+    label: Input File
+    doc: "The file that will be copied using 'cat'"
+    inputBinding: {position: 1}
+outputs:
+  output_file:
+    type: File
+    outputBinding: {glob: output.txt}
+baseCommand: cat
+stdout: output.txt


### PR DESCRIPTION
Exact same test as 81, but without the Docker hint.

Fails with latest cwltool