### PR TITLE
Fix doc for dir3.cwl test.

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -881,7 +881,7 @@
         ],
     }
   tool: v1.0/dir3.cwl
-  doc: Test directory input in Docker
+  doc: Test directory output
 
 - job: v1.0/dir4-job.yml
   output: {


### PR DESCRIPTION
A different test had this doc and the test doesn't use Docker and seems to be testing directory outputs instead of directory inputs.