### PR TITLE
Fix indent in the example of stdout

### DIFF
--- a/v1.0/CommandLineTool.yml
+++ b/v1.0/CommandLineTool.yml
@@ -440,8 +440,8 @@ $graph:
     The following
     ```
     outputs:
-       an_output_name:
-       type: stdout
+      an_output_name:
+        type: stdout
 
     stdout: a_stdout_file
     ```

--- a/v1.1.0-dev1/CommandLineTool.yml
+++ b/v1.1.0-dev1/CommandLineTool.yml
@@ -467,8 +467,8 @@ $graph:
     The following
     ```
     outputs:
-       an_output_name:
-       type: stdout
+      an_output_name:
+        type: stdout
 
     stdout: a_stdout_file
     ```


### PR DESCRIPTION
This request fixes the indent in the example snippet of stdout in 5.2.1.
It makes consistent with the specification and the example.

Before:
```yaml
outputs:
   an_output_name:
   type: stdout

stdout: a_stdout_file
```

Fixed:
```yaml
outputs:
  an_output_name:
    type: stdout

stdout: a_stdout_file
```
