### PR TITLE
Update Debian Docker image used in the v1.0 tests

### DIFF
--- a/v1.0/v1.0/cat3-tool-mediumcut.cwl
+++ b/v1.0/v1.0/cat3-tool-mediumcut.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
 hints:
   DockerRequirement:
-    dockerPull: debian:wheezy
+    dockerPull: debian:stretch-slim
 inputs:
   file1:
     type: File

--- a/v1.0/v1.0/cat3-tool-shortcut.cwl
+++ b/v1.0/v1.0/cat3-tool-shortcut.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
 hints:
   DockerRequirement:
-    dockerPull: debian:wheezy
+    dockerPull: debian:stretch-slim
 inputs:
   file1:
     type: File

--- a/v1.0/v1.0/cat3-tool.cwl
+++ b/v1.0/v1.0/cat3-tool.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
 hints:
   DockerRequirement:
-    dockerPull: debian:wheezy
+    dockerPull: debian:stretch-slim
 inputs:
   file1:
     type: File

--- a/v1.0/v1.0/cat4-tool.cwl
+++ b/v1.0/v1.0/cat4-tool.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
 hints:
   DockerRequirement:
-    dockerPull: debian:wheezy
+    dockerPull: debian:stretch-slim
 inputs:
   file1: File
 outputs:

--- a/v1.0/v1.0/cat5-tool.cwl
+++ b/v1.0/v1.0/cat5-tool.cwl
@@ -6,7 +6,7 @@ class: CommandLineTool
 doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
 hints:
   DockerRequirement:
-    dockerPull: "debian:wheezy"
+    dockerPull: "debian:stretch-slim"
   ex:BlibberBlubberFakeRequirement:
     fakeField: fraggleFroogle
 inputs:

--- a/v1.0/v1.0/dir2.cwl
+++ b/v1.0/v1.0/dir2.cwl
@@ -2,7 +2,7 @@ class: CommandLineTool
 cwlVersion: v1.0
 hints:
   DockerRequirement:
-    dockerPull: debian:8
+    dockerPull: debian:stretch-slim
   ShellCommandRequirement: {}
 inputs:
   indir: Directory

--- a/v1.0/v1.0/docker-array-secondaryfiles.cwl
+++ b/v1.0/v1.0/docker-array-secondaryfiles.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 
 requirements:
   - class: DockerRequirement
-    dockerPull: debian:8
+    dockerPull: debian:stretch-slim
   - class: InlineJavascriptRequirement
   - class: ShellCommandRequirement
 

--- a/v1.0/v1.0/docker-output-dir.cwl
+++ b/v1.0/v1.0/docker-output-dir.cwl
@@ -2,7 +2,7 @@ class: CommandLineTool
 cwlVersion: v1.0
 requirements:
   DockerRequirement:
-    dockerPull: debian:8
+    dockerPull: debian:stretch-slim
     dockerOutputDirectory: /other
 inputs: []
 outputs:

--- a/v1.0/v1.0/envvar2.cwl
+++ b/v1.0/v1.0/envvar2.cwl
@@ -6,7 +6,7 @@ requirements:
   ShellCommandRequirement: {}
 hints:
   DockerRequirement:
-    dockerPull: debian:8
+    dockerPull: debian:stretch-slim
 arguments: [
   echo, {valueFrom: '"HOME=$HOME"', shellQuote: false}, {valueFrom: '"TMPDIR=$TMPDIR"', shellQuote: false},
   {valueFrom: '&&', shellQuote: false},

--- a/v1.0/v1.0/formattest2.cwl
+++ b/v1.0/v1.0/formattest2.cwl
@@ -7,7 +7,7 @@ cwlVersion: v1.0
 doc: "Reverse each line using the `rev` command"
 hints:
   DockerRequirement:
-    dockerPull: "debian:wheezy"
+    dockerPull: "debian:stretch-slim"
 
 inputs:
   input:

--- a/v1.0/v1.0/formattest3.cwl
+++ b/v1.0/v1.0/formattest3.cwl
@@ -9,7 +9,7 @@ cwlVersion: v1.0
 doc: "Reverse each line using the `rev` command"
 hints:
   DockerRequirement:
-    dockerPull: "debian:wheezy"
+    dockerPull: "debian:stretch-slim"
 
 inputs:
   input:

--- a/v1.0/v1.0/initialworkdirrequirement-docker-out.cwl
+++ b/v1.0/v1.0/initialworkdirrequirement-docker-out.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 
 requirements:
   - class: DockerRequirement
-    dockerPull: debian:8
+    dockerPull: debian:stretch-slim
   - class: InitialWorkDirRequirement
     listing:
       - $(inputs.INPUT)

--- a/v1.0/v1.0/metadata.cwl
+++ b/v1.0/v1.0/metadata.cwl
@@ -18,7 +18,7 @@ dct:creator:
 
 hints:
   DockerRequirement:
-    dockerPull: debian:wheezy
+    dockerPull: debian:stretch-slim
 inputs:
   file1:
     type: File

--- a/v1.0/v1.0/optional-output.cwl
+++ b/v1.0/v1.0/optional-output.cwl
@@ -4,7 +4,7 @@ cwlVersion: "v1.0"
 doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
 hints:
   DockerRequirement:
-    dockerPull: debian:wheezy
+    dockerPull: debian:stretch-slim
 inputs:
   file1:
     type: File

--- a/v1.0/v1.0/revsort-packed.cwl
+++ b/v1.0/v1.0/revsort-packed.cwl
@@ -7,7 +7,7 @@
             "hints": [
                 {
                     "class": "DockerRequirement", 
-                    "dockerPull": "debian:8"
+                    "dockerPull": "debian:stretch-slim"
                 }
             ], 
             "inputs": [

--- a/v1.0/v1.0/revsort.cwl
+++ b/v1.0/v1.0/revsort.cwl
@@ -10,7 +10,7 @@ cwlVersion: v1.0
 # in which the command line tools will execute.
 hints:
   - class: DockerRequirement
-    dockerPull: debian:8
+    dockerPull: debian:stretch-slim
 
 
 # The inputs array defines the structure of the input object that describes

--- a/v1.0/v1.0/template-tool.cwl
+++ b/v1.0/v1.0/template-tool.cwl
@@ -12,7 +12,7 @@ requirements:
         entry: $(t("The file is <%= inputs.file1.path.split('/').slice(-1)[0] %>\n"))
 hints:
   DockerRequirement:
-    dockerPull: "debian:8"
+    dockerPull: "debian:stretch-slim"
 inputs:
   - id: file1
     type: File

--- a/v1.0/v1.0/test-cwl-out.cwl
+++ b/v1.0/v1.0/test-cwl-out.cwl
@@ -4,7 +4,7 @@ requirements:
   - class: ShellCommandRequirement
 hints:
   DockerRequirement:
-    dockerPull: "debian:wheezy"
+    dockerPull: "debian:stretch-slim"
 
 inputs: []
 

--- a/v1.0/v1.0/test-cwl-out2.cwl
+++ b/v1.0/v1.0/test-cwl-out2.cwl
@@ -4,7 +4,7 @@ requirements:
   - class: ShellCommandRequirement
 hints:
   DockerRequirement:
-    dockerPull: "debian:wheezy"
+    dockerPull: "debian:stretch-slim"
 
 inputs: []
 


### PR DESCRIPTION
Run all v1.0 tests that use a Debian Docker image with the debian:stretch-slim image instead of debian:8 or debian:wheezy.

The debian:stretch-slim is smaller than either of the others.