### PR TITLE
draft-3/README.md: Link address changed

### DIFF
--- a/draft-3/README.md
+++ b/draft-3/README.md
@@ -2,7 +2,7 @@
 
 The CWL specifications are divided up into several documents.
 
-The [User Guide](UserGuide.html) provides a gentle introduction to writing CWL
+The [User Guide](http://www.commonwl.org/user_guide/) provides a gentle introduction to writing CWL
 command line tools and workflows.
 
 The [Command Line Tool Description Specification](CommandLineTool.html)

--- a/draft-3/README.md
+++ b/draft-3/README.md
@@ -1,20 +1,23 @@
-# Common Workflow Language Specifications, draft-3
+# Outdated, please refer to CWL version 1.0 specifications
 
-The CWL specifications are divided up into several documents.
+This URL is for the outdated "draft-3" version of the Common Workflow Language standards.
 
-The [User Guide](http://www.commonwl.org/user_guide/) provides a gentle introduction to writing CWL
-command line tools and workflows.
+Please go to https://w3id.org/cwl/ for the latest stable version.
 
-The [Command Line Tool Description Specification](CommandLineTool.html)
+## Common Workflow Language Specifications, draft-3
+
+The CWL draft-3 specifications are divided up into several documents.
+
+The [CWL draft-3 Command Line Tool Description Specification](CommandLineTool.html)
 specifies the document schema and execution semantics for wrapping and
 executing command line tools.
 
-The [Workflow Description Specification](Workflow.html) specifies the document
+The [CWL draft-3 Workflow Description Specification](Workflow.html) specifies the document
 schema and execution semantics for composing workflows from components such as
 command line tools and other workflows.
 
 The
-[Semantic Annotations for Linked Avro Data (SALAD) Specification](SchemaSalad.html)
+[draft-3 version Semantic Annotations for Linked Avro Data (SALAD) Specification](SchemaSalad.html)
 specifies the preprocessing steps that must be applied when loading CWL
 documents and the schema language used to write the above specifications.
 


### PR DESCRIPTION
UserGuide.html was non existent in the repository, hence corrected to http://www.commonwl.org/user_guide/
Fixes: https://github.com/common-workflow-language/common-workflow-language/issues/538