### PR TITLE
Adding conformance test for workflow default override

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -222,6 +222,11 @@
   tool: v1.0/count-lines5-wf.cwl
   doc: Test workflow with default value for input parameter (provided)
 
+- job: v1.0/empty.json
+  output: {default_output: workflow_default}
+  tool: v1.0/echo-wf-default.cwl
+  doc: Test that workflow defaults override tool defaults
+
 - job: v1.0/env-job.json
   output:
     out:

--- a/v1.0/v1.0/echo-tool-default.cwl
+++ b/v1.0/v1.0/echo-tool-default.cwl
@@ -1,0 +1,19 @@
+#!/usr/bin/env cwl-runner
+
+class: CommandLineTool
+cwlVersion: v1.0
+inputs:
+  in:
+    type: string
+    default: tool_default
+    inputBinding:
+      position: 1
+outputs:
+  out:
+    type: string
+    outputBinding:
+      glob: out.txt
+      loadContents: true
+      outputEval: $(self[0].contents)
+baseCommand: [echo, -n]
+stdout: out.txt

--- a/v1.0/v1.0/echo-wf-default.cwl
+++ b/v1.0/v1.0/echo-wf-default.cwl
@@ -1,0 +1,19 @@
+
+class: Workflow
+cwlVersion: v1.0
+
+inputs: []
+
+steps:
+  step1:
+    run: echo-tool-default.cwl
+    in:
+      in: 
+        default: workflow_default
+    out: [out]
+    
+outputs:
+    default_output:
+      type: string
+      outputSource: step1/out
+


### PR DESCRIPTION
Making sure workflow default overrides the tool default. 
Fixes issue https://github.com/common-workflow-language/cwltool/issues/592
cwltool issue fixed in https://github.com/common-workflow-language/cwltool/pull/595
