### PR TITLE
Using requirements instead of hints

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -72,11 +72,11 @@
       checksum: sha1$47a013e660d408619d894b20806b1d5086aab03b
       location: output.txt
       size: 13
-  tool: v1.0/cat3-tool.cwl
+  tool: v1.0/cat3-tool-docker.cwl
   label: stdout_redirect_docker
   id: 7
   doc: Test command execution in Docker with stdout redirection
-  tags: [ required, command_line_tool ]
+  tags: [ docker, command_line_tool ]
 
 - job: v1.0/cat-job.json
   tool: v1.0/cat3-tool-shortcut.cwl
@@ -89,7 +89,7 @@
   label: stdout_redirect_shortcut_docker
   id: 8
   doc: Test command execution in Docker with shortcut stdout redirection
-  tags: [ required, command_line_tool ]
+  tags: [ docker, command_line_tool ]
 
 - job: v1.0/cat-job.json
   output:
@@ -102,7 +102,7 @@
   label: stdout_redirect_mediumcut_docker
   id: 9
   doc: Test command execution in Docker with mediumcut stdout redirection
-  tags: [ required, command_line_tool ]
+  tags: [ docker, command_line_tool ]
 
 - job: v1.0/empty.json
   tool: v1.0/stderr.cwl

--- a/v1.0/v1.0/cat3-tool-docker.cwl
+++ b/v1.0/v1.0/cat3-tool-docker.cwl
@@ -2,7 +2,7 @@
 class: CommandLineTool
 cwlVersion: v1.0
 doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
-hints:
+requirements:
   DockerRequirement:
     dockerPull: debian:stretch-slim
 inputs:

--- a/v1.0/v1.0/cat3-tool-mediumcut.cwl
+++ b/v1.0/v1.0/cat3-tool-mediumcut.cwl
@@ -2,7 +2,7 @@
 class: CommandLineTool
 cwlVersion: v1.0
 doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
-hints:
+requirements:
   DockerRequirement:
     dockerPull: debian:stretch-slim
 inputs:

--- a/v1.0/v1.0/cat3-tool-shortcut.cwl
+++ b/v1.0/v1.0/cat3-tool-shortcut.cwl
@@ -2,7 +2,7 @@
 class: CommandLineTool
 cwlVersion: v1.0
 doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
-hints:
+requirements:
   DockerRequirement:
     dockerPull: debian:stretch-slim
 inputs:

--- a/v1.0/v1.0/cat3-tool.cwl
+++ b/v1.0/v1.0/cat3-tool.cwl
@@ -2,7 +2,7 @@
 class: CommandLineTool
 cwlVersion: v1.0
 doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
-hints:
+requirements:
   DockerRequirement:
     dockerPull: debian:stretch-slim
 inputs:


### PR DESCRIPTION
In terms of `doc` comment in conformance_test_v1.0.yaml
These 3 files using for Docker.
These 3 tests are needed to use `requirements`.

But `cat3-tool.cwl` is used as
I don't know how to effect this.
I think following test using another file.

```
- job: v1.0/file-literal.yml
  output:
    output_file:
      class: File
      checksum: sha1$d0e04ff6c413c7d57f9a0ca0a33cd3ab52e2dd9c
      location: output.txt
      size: 18
  tool: v1.0/cat3-tool.cwl
  doc: Test file literal as input
```