### PR TITLE
Replace `wc` with `cat` to improve test's portability

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -152,14 +152,14 @@
     output: 2
   doc: Testing the string 'null' does not trip up an Any without a default value.
 
-- job: v1.0/wc-job.json
+- job: v1.0/cat-job.json
   output:
     output:
-      checksum: sha1$3596ea087bfdaf52380eae441077572ed289d657
+      checksum: sha1$47a013e660d408619d894b20806b1d5086aab03b
       class: File
       location: output
-      size: 3
-  tool: v1.0/wc-tool.cwl
+      size: 13
+  tool: v1.0/cat-tool.cwl
   doc: Test command execution in with stdin and stdout redirection
 
 - job: v1.0/parseInt-job.json

--- a/v1.0/v1.0/cat-tool.cwl
+++ b/v1.0/v1.0/cat-tool.cwl
@@ -1,0 +1,17 @@
+#!/usr/bin/env cwl-runner
+
+class: CommandLineTool
+cwlVersion: v1.0
+
+inputs:
+  file1: File
+
+outputs:
+  output:
+    type: File
+    outputBinding: { glob: output }
+
+baseCommand: [cat]
+
+stdin: $(inputs.file1.path)
+stdout: output


### PR DESCRIPTION
Closes #79 