### PR TITLE
Add test for InitialWorkDir contents to be non-writable

### DIFF
--- a/v1.1.0-dev1/conformance_test_v1.1.0-dev1.yaml
+++ b/v1.1.0-dev1/conformance_test_v1.1.0-dev1.yaml
@@ -1101,6 +1101,11 @@
   tool: v1.1.0-dev1/recursive-input-directory.cwl
   doc: Test if a writable input directory is recursivly copied and writable
 
+- doc: Test that directories inside initial working directory are not writable by default
+  job: v1.1.0-dev1/empty.json
+  tool: v1.1.0-dev1/iwdr_listing_non_writable.cwl
+  should_fail: true
+
 - output:
     out: "t\n"
   job: v1.1.0-dev1/empty.json

--- a/v1.1.0-dev1/v1.1.0-dev1/iwdr_listing_non_writable.cwl
+++ b/v1.1.0-dev1/v1.1.0-dev1/iwdr_listing_non_writable.cwl
@@ -1,0 +1,40 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.1.0-dev1
+class: Workflow
+
+inputs: []
+outputs:
+  outfile:
+    type: File
+    outputSource: second/outfile
+
+steps:
+  first:
+    run:
+      class: CommandLineTool
+      baseCommand: [ mkdir, directory ]
+      inputs: []
+      outputs:
+        dir:
+          type: Directory
+          outputBinding: { glob: directory }
+    in: {}
+    out: [ dir ]
+
+  second:
+    run:
+      class: CommandLineTool
+      baseCommand: [ touch, directory/file ]
+      requirements:
+        InitialWorkDirRequirement:
+          listing:
+            - entry: $(inputs.dir)
+      inputs:
+        dir: Directory
+      outputs:
+        outfile:
+          type: File
+          outputBinding: { glob: directory/file }
+
+    in: { dir: first/dir }
+    out: [ outfile ]


### PR DESCRIPTION
closes https://github.com/common-workflow-language/common-workflow-language/issues/591
currently, cwltool returns 0 code for this test, i.e. fails it