### PR TITLE
Using requirements instead of hints

### DIFF
--- a/v1.0/v1.0/cat3-tool-mediumcut.cwl
+++ b/v1.0/v1.0/cat3-tool-mediumcut.cwl
@@ -2,7 +2,7 @@
 class: CommandLineTool
 cwlVersion: v1.0
 doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
-hints:
+requirements:
   DockerRequirement:
     dockerPull: debian:stretch-slim
 inputs:

--- a/v1.0/v1.0/cat3-tool-shortcut.cwl
+++ b/v1.0/v1.0/cat3-tool-shortcut.cwl
@@ -2,7 +2,7 @@
 class: CommandLineTool
 cwlVersion: v1.0
 doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
-hints:
+requirements:
   DockerRequirement:
     dockerPull: debian:stretch-slim
 inputs:


### PR DESCRIPTION
From conformance test's comment,
these files MUST use `requirements` instead of `hints`.

conformance test 8

```
tool: v1.0/cat3-tool-shortcut.cwl
doc: Test command execution in Docker with simplified syntax stdout redirection
```

conformance test 9

```
 tool: v1.0/cat3-tool-mediumcut.cwl
 doc: Test command execution in Docker with stdout redirection
```