### PR TITLE
Add DockerRequirement for `python` command in valueFrom-constant.cwl

### DIFF
--- a/v1.0/v1.0/valueFrom-constant.cwl
+++ b/v1.0/v1.0/valueFrom-constant.cwl
@@ -1,7 +1,13 @@
 class: CommandLineTool
 cwlVersion: v1.0
+
 requirements:
-- class: InlineJavascriptRequirement
+  - class: InlineJavascriptRequirement
+
+hints:
+  - class: DockerRequirement
+    dockerPull: python:2-slim
+
 inputs:
   - id: array_input
     type:
@@ -9,7 +15,6 @@ inputs:
         items: string
     inputBinding:
       valueFrom: replacementValue
-
 
   - id: args.py
     type: File
@@ -22,4 +27,5 @@ inputs:
 outputs:
   - id: args
     type: string[]
+
 baseCommand: python


### PR DESCRIPTION
Needed for REANA conformance since it uses default containers for workflows without Docker, and `frolvlad/alpine-bash` does not carry Python on board