### PR TITLE
Do not assume output file is present in dynamic iwdr test

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -926,8 +926,8 @@
 - job: v1.0/dir-job.yml
   output: {
     "outlist": {
-        "checksum": "sha1$907a866a3e0b7f1fc5a2222531c5fb9063704438",
-        "size": 33,
+        "checksum": "sha1$13cda8661796ae241da3a18668fb552161a72592",
+        "size": 20,
         "location": "output.txt",
         "class": "File"
     }

--- a/v1.0/v1.0/dir5.cwl
+++ b/v1.0/v1.0/dir5.cwl
@@ -11,7 +11,7 @@ outputs:
     type: File
     outputBinding:
       glob: output.txt
-arguments: ["find", "-L", ".",
+arguments: ["find", "-L", ".", "!", "-path", "*.txt",
   {shellQuote: false, valueFrom: "|"},
   "sort"]
 stdout: output.txt


### PR DESCRIPTION
Currently, the testing command `find -L . | sort > output.txt` in `Test dynamic initial work dir` also checks that output file `output.txt` is created before `find` command execution which might not be true for all platforms and is not a part of InitialWorkDirRequirement.

*dir5.cwl*
```
class: CommandLineTool
cwlVersion: v1.0
requirements:
  - class: ShellCommandRequirement
  - class: InitialWorkDirRequirement
    listing: $(inputs.indir.listing)
inputs:
  indir: Directory
outputs:
  outlist:
    type: File
    outputBinding:
      glob: output.txt
arguments: ["find", "-L", ".", 
  {shellQuote: false, valueFrom: "|"},
  "sort"]
stdout: output.txt
```
*Output*
```
{
    "outlist": {
        "checksum": "sha1$907a866a3e0b7f1fc5a2222531c5fb9063704438", 
        "basename": "output.txt", 
        "nameext": ".txt", 
        "nameroot": "output", 
        "http://commonwl.org/cwltool#generation": 0, 
        "location": "file:///private/tmp/docker_tmp_3KRZX/output.txt", 
        "class": "File", 
        "size": 33
    }
}
```
*output.txt*
```
.
./a
./b
./c
./c/d
./output.txt
```
So the conformance test will fail if the output file is created after the `find` command execution. This PR amends the test so only the input directory contents are checked for existing in the initial working directory. It does not affect the existing implementations' results but is helpful to implementations where `output.txt` is created *after* `find` command execution.