### PR TITLE
Fewer conformance reqs

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -518,7 +518,8 @@
   tool: "v1.0/search.cwl#main"
   doc: |
     Test InitialWorkDirRequirement linking input files and capturing secondaryFiles
-    on input and output.
+    on input and output. Also tests the use of a variety of parameter references
+    and expressions in the secondaryFiles field.
   tags: [ initial_work_dir, inline_javascript ]
 
 - job: v1.0/rename-job.json
@@ -562,7 +563,7 @@
   tool: v1.0/schemadef-tool.cwl
   doc: |
     Test SchemaDefRequirement definition used in tool parameter
-  tags: [ schema_def, inline_javascript ]
+  tags: [ schema_def ]
 
 - job: v1.0/schemadef-job.json
   output:
@@ -1285,7 +1286,7 @@
       }
   tool: v1.0/recursive-input-directory.cwl
   doc: Test if a writable input directory is recursivly copied and writable
-  tags: [ inline_javascript, initial_work_dir, shell_command ]
+  tags: [ initial_work_dir, shell_command ]
 
 - output:
     out: "t\n"
@@ -1515,7 +1516,7 @@
   tool: v1.0/stage-unprovided-file.cwl
   doc: Test that expression engine does not fail to evaluate reference to self
        with unprovided input
-  tags: [ inline_javascript ]
+  tags: [ required ]
 
 - tool: v1.0/exit-success.cwl
   doc: Test successCodes
@@ -1561,4 +1562,4 @@
   }
   tool: v1.0/valueFrom-constant.cwl
   doc: Test valueFrom with constant value overriding provided array inputs
-  tags: [ inline_javascript ]
+  tags: [ required ]

--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -1059,13 +1059,13 @@
 - job: v1.0/arguments-job.yml
   output:
     classfile:
-        checksum: sha1$e68df795c0686e9aa1a1195536bd900f5f417b18
+        checksum: sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709
         location: Hello.class
         class: File
-        size: 184
+        size: 0
   tool: v1.0/linkfile.cwl
   doc: Test expression in InitialWorkDir listing
-  tags: [ inline_javascript, initial_work_dir ]
+  tags: [ initial_work_dir ]
 
 - job: v1.0/wc-job.json
   output:

--- a/v1.0/v1.0/linkfile.cwl
+++ b/v1.0/v1.0/linkfile.cwl
@@ -1,13 +1,8 @@
 cwlVersion: v1.0
 class: CommandLineTool
-hints:
-  DockerRequirement:
-    dockerPull: java:7
-baseCommand: javac
 
 requirements:
-  - class: InlineJavascriptRequirement
-  - class: InitialWorkDirRequirement
+  InitialWorkDirRequirement:
     listing:
       - $(inputs.src)
 
@@ -16,7 +11,9 @@ inputs:
     type: File
     inputBinding:
       position: 1
-      valueFrom: $(self.basename)
+      valueFrom: $(self.nameroot).class
+
+baseCommand: touch
 
 outputs:
   classfile:

--- a/v1.0/v1.0/params2.cwl
+++ b/v1.0/v1.0/params2.cwl
@@ -1,7 +1,7 @@
 class: CommandLineTool
 cwlVersion: v1.0
 requirements:
-  - class: InlineJavascriptRequirement
+  - class: InlineJavascriptRequirement  # needed by params_inc.yml
 
 inputs:
   bar:

--- a/v1.0/v1.0/recursive-input-directory.cwl
+++ b/v1.0/v1.0/recursive-input-directory.cwl
@@ -1,13 +1,12 @@
 cwlVersion: v1.0
 class: CommandLineTool
 requirements:
-  - class: InlineJavascriptRequirement
-  - class: InitialWorkDirRequirement
+  InitialWorkDirRequirement:
     listing:
       - entry: $(inputs.input_dir)
         entryname: work_dir
         writable: true
-  - class: ShellCommandRequirement
+  ShellCommandRequirement: {}
 stdout: output.txt
 arguments:
  - shellQuote: false

--- a/v1.0/v1.0/schemadef-tool.cwl
+++ b/v1.0/v1.0/schemadef-tool.cwl
@@ -1,15 +1,15 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
 cwlVersion: v1.0
+
 requirements:
   - $import: schemadef-type.yml
-  - class: InlineJavascriptRequirement
 
 inputs:
     - id: hello
       type: "schemadef-type.yml#HelloType"
       inputBinding:
-        valueFrom: $(self.a + "/" + self.b)
+        valueFrom: $(self.a)/$(self.b)
 
 outputs:
     - id: output

--- a/v1.0/v1.0/stage-unprovided-file.cwl
+++ b/v1.0/v1.0/stage-unprovided-file.cwl
@@ -1,8 +1,6 @@
 cwlVersion: v1.0
 class: CommandLineTool
 
-requirements: { InlineJavascriptRequirement: {} }
-
 inputs:
   - id: infile
     type: File?

--- a/v1.0/v1.0/valueFrom-constant.cwl
+++ b/v1.0/v1.0/valueFrom-constant.cwl
@@ -1,9 +1,6 @@
 class: CommandLineTool
 cwlVersion: v1.0
 
-requirements:
-  - class: InlineJavascriptRequirement
-
 hints:
   - class: DockerRequirement
     dockerPull: python:2-slim


### PR DESCRIPTION
There is no need to require `javac` for non container using systems