### PR TITLE
Add python docker to stage-unprovided-file test

### DIFF
--- a/v1.0/v1.0/bool-empty-inputbinding.cwl
+++ b/v1.0/v1.0/bool-empty-inputbinding.cwl
@@ -1,6 +1,9 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
 cwlVersion: v1.0
+hints:
+  - class: DockerRequirement
+    dockerPull: python:2-slim
 inputs:
 - id: flag
   type: boolean

--- a/v1.0/v1.0/stage-unprovided-file.cwl
+++ b/v1.0/v1.0/stage-unprovided-file.cwl
@@ -1,6 +1,8 @@
 cwlVersion: v1.0
 class: CommandLineTool
-
+hints:
+  - class: DockerRequirement
+    dockerPull: python:2-slim
 inputs:
   - id: infile
     type: File?
@@ -20,4 +22,3 @@ baseCommand: python
 outputs:
 - id: args
   type: string[]
-


### PR DESCRIPTION
This test seems like it should have a docker `hint` since it uses `python` as the `baseCommand` ? Otherwise it implicitly requires the machine to have python installed.