### PR TITLE
Add test that inputs not connected to tool parameter doesn't get passed

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -1542,7 +1542,7 @@
     "args": []
   }
   tool: v1.0/empty-array-input.cwl
-  doc: "Test that empty array input does not add anything to command line" 
+  doc: "Test that empty array input does not add anything to command line"
   tags: [ required ]
 
 - job: v1.0/empty.json
@@ -1577,3 +1577,19 @@
      }
   tags: [ resource ]
 
+- job: v1.0/empty.json
+  tool: v1.0/pass-unconnected.cwl
+  doc: |
+    Test that it is not an error to connect a parameter to a workflow
+    step, even if the parameter doesn't appear in the `run` process
+    inputs.
+  output: { "out": "hello inp1\n" }
+  tags: [ required ]
+
+- job: v1.0/empty.json
+  tool: v1.0/fail-unconnected.cwl
+  doc: |
+    Test that parameters that doesn't appear in the `run` process
+    inputs are not present in the input object used to run the tool.
+  should_fail: true
+  tags: [ required ]

--- a/v1.0/v1.0/fail-unconnected.cwl
+++ b/v1.0/v1.0/fail-unconnected.cwl
@@ -1,0 +1,20 @@
+class: Workflow
+cwlVersion: v1.0
+inputs:
+  inp1:
+    type: string
+    default: hello inp1
+  inp2:
+    type: string
+    default: hello inp2
+outputs:
+  out:
+    type: string
+    outputSource: step1/out
+steps:
+  step1:
+    in:
+      in: inp1
+      in2: inp2
+    out: [out]
+    run: fail-unspecified-input.cwl

--- a/v1.0/v1.0/fail-unspecified-input.cwl
+++ b/v1.0/v1.0/fail-unspecified-input.cwl
@@ -1,0 +1,13 @@
+class: CommandLineTool
+cwlVersion: v1.0
+inputs:
+  in: string
+outputs:
+  out:
+    type: string
+    outputBinding:
+      glob: out.txt
+      loadContents: true
+      outputEval: $(self[0].contents)
+stdout: out.txt
+arguments: [echo, $(inputs.in), $(inputs.in2)]

--- a/v1.0/v1.0/pass-unconnected.cwl
+++ b/v1.0/v1.0/pass-unconnected.cwl
@@ -1,0 +1,20 @@
+class: Workflow
+cwlVersion: v1.0
+inputs:
+  inp1:
+    type: string
+    default: hello inp1
+  inp2:
+    type: string
+    default: hello inp2
+outputs:
+  out:
+    type: string
+    outputSource: step1/out
+steps:
+  step1:
+    in:
+      in: inp1
+      in2: inp2
+    out: [out]
+    run: echo-tool.cwl


### PR DESCRIPTION
in the input object.

Corresponds to cwltool fix https://github.com/common-workflow-language/cwltool/pull/765