### PR TITLE
Correct which test should fail

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -1518,7 +1518,6 @@
   doc: Test that expression engine does not fail to evaluate reference to self
        with unprovided input
   tags: [ required ]
-  should_fail: true
 
 - tool: v1.0/exit-success.cwl
   doc: Test successCodes

--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -799,6 +799,7 @@
   tool: v1.0/vf-concat.cwl
   doc: Test that second expression in concatenated valueFrom is not ignored
   tags: [ inline_javascript ]
+  should_fail: true
 
 - job: v1.0/step-valuefrom-wf.json
   output: {count_output: 16}


### PR DESCRIPTION
I made a mess and I apologize.  From #679 , the agreed result was that this evaluation should not be happening as the input is not being provided.  

Unfortunately, I removed the wrong test!  in #694 .  This test correctly asserts that the expression is _not_ evaluated when the input is not provided.  I.e. the expression is only evaluated when the input is provided.

This PR puts things the way they should have been.

Very sorry for the mixup.

