### PR TITLE
test for parameter references in CommandLineTool.arguments

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -1593,3 +1593,15 @@
     inputs are not present in the input object used to run the tool.
   should_fail: true
   tags: [ required ]
+- job: v1.0/empty.json
+  tool: v1.0/paramref_arguments_runtime.cwl
+  doc: confirm that $runtime is available to parameter references in arguments
+  tags: [ required ]
+  output:
+    "runtime_review": {
+        "basename": "runtime_review.txt",
+        "class": "File",
+        "checksum": "sha1$c01db123f62c07b8431d67e0e409a9f7de974f5c",
+        "size": 30,
+    }
+

--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -1598,10 +1598,29 @@
   doc: confirm that $runtime is available to parameter references in arguments
   tags: [ required ]
   output:
-    "runtime_review": {
-        "basename": "runtime_review.txt",
-        "class": "File",
-        "checksum": "sha1$c01db123f62c07b8431d67e0e409a9f7de974f5c",
-        "size": 30,
-    }
+    runtime_review:
+        basename: runtime_review.txt
+        class: File
+        checksum: "sha1$c01db123f62c07b8431d67e0e409a9f7de974f5c"
+        size: 30
+- tool: v1.0/paramref_arguments_self.cwl
+  job: v1.0/empty.json
+  doc: confirm that $self is available and set to null in arguments
+  tags: [ required ]
+  output:
+    self_review:
+      location: self_review.txt
+      class: File
+      checksum: "sha1$724ba28f4a9a1b472057ff99511ed393a45552e1"
+      size: 5
+- job: v1.0/empty.json
+  tool: v1.0/paramref_arguments_inputs.cwl
+  doc: confirm that $inputs is available to parameter references in arguments
+  tags: [ required ]
+  output:
+    inputs_review:
+        location: inputs_review.txt
+        class: File
+        checksum: "sha1$724ba28f4a9a1b472057ff99511ed393a45552e1"
+        size: 5
 

--- a/v1.0/v1.0/paramref_arguments_inputs.cwl
+++ b/v1.0/v1.0/paramref_arguments_inputs.cwl
@@ -1,0 +1,97 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: Workflow
+inputs: []
+outputs:
+  inputs_review:
+    type: File
+    outputSource: evaluate_inputs/inputs_review
+steps:
+  record_inputs:
+    run:
+      class: CommandLineTool
+      inputs:
+        a_string:
+          type: string
+          default: z
+        a_string_array:
+          type: string[]
+          default: [a, b, c]
+        a_true:
+          type: boolean
+          default: true
+        an_array_of_trues:
+          type: boolean[]
+          default: [true, true, true]
+        an_array_of_falses:
+          type: boolean[]
+          default: [false, false, false]
+        an_array_of_mixed_booleans:
+          type: boolean[]
+          default: [false, true, false]
+        an_int:
+          type: int
+          default: 42
+        an_array_of_ints:
+          type: int[]
+          default: [42, 23]
+        a_long:
+          type: long
+          default: 4147483647
+        an_array_of_longs:
+          type: long[]
+          default: [4147483647, -4147483647]
+        a_float:
+          type: float
+          default: 4.2
+        an_array_of_floats:
+          type: float[]
+          default: [2.3, 4.2]
+        a_double:
+          type: double
+          default: 1000000000000000000000000000000000000000000
+        an_array_of_doubles:
+          type: double[]
+          default:
+            - 1000000000000000000000000000000000000000000
+            - -1000000000000000000000000000000000000000000
+      arguments:
+       - '{"inputs":$(inputs)}'
+      outputs:
+        inputs_dump: stdout
+      baseCommand: echo
+      stdout: inputs.json
+    in: []
+    out: [inputs_dump]
+  evaluate_inputs:
+    run:
+      class: CommandLineTool
+      hints:
+        DockerRequirement:
+          dockerPull: everpeace/curl-jq
+      inputs:
+        inputs_json:
+          type: File
+          inputBinding:
+            position: 2
+      stdout: inputs_review.txt
+      outputs:
+       inputs_review: stdout
+      baseCommand: jq
+      arguments:
+       - valueFrom: >
+          .inputs == { "a_string": "z", "a_string_array": ["a", "b", "c"],
+                       "a_true": true, "an_array_of_trues": [true, true, true],
+                       "an_array_of_falses": [false, false, false],
+                       "an_array_of_mixed_booleans": [false, true, false],
+                       "an_int": 42, "an_array_of_ints": [42, 23],
+                       "a_long": 4147483647,
+                       "an_array_of_longs": [4147483647, -4147483647],
+                       "a_float": 4.2, "an_array_of_floats": [2.3,4.2],
+                       "a_double": 1000000000000000000000000000000000000000000,
+                       "an_array_of_doubles": [1000000000000000000000000000000000000000000,-1000000000000000000000000000000000000000000]}
+         position: 1
+    in: { inputs_json: record_inputs/inputs_dump }
+    out: [ inputs_review ]
+      
+

--- a/v1.0/v1.0/paramref_arguments_runtime.cwl
+++ b/v1.0/v1.0/paramref_arguments_runtime.cwl
@@ -1,0 +1,44 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: Workflow
+inputs: []
+outputs:
+  runtime_review:
+    type: File
+    outputSource: evaluate_runtime/runtime_review
+steps:
+  record_runtime:
+    run:
+      class: CommandLineTool
+      baseCommand: echo
+      inputs: []
+      arguments:
+       - '{"runtime":$(runtime)}'
+      stdout: runtime.json
+      outputs:
+        runtime: stdout
+    in: []
+    out: [runtime]
+  evaluate_runtime:
+    run:
+      class: CommandLineTool
+      hints:
+        DockerRequirement:
+          dockerPull: everpeace/curl-jq
+      inputs:
+        runtime:
+          type: File
+          inputBinding:
+            position: 2
+      stdout: runtime_review.txt
+      outputs:
+        runtime_review: stdout
+      baseCommand: jq
+      arguments:
+       - valueFrom: |
+          .runtime | has("cores"), has("outdir"), has("outdirSize"), has("ram"), has("tmpdir"), has("tmpdirSize")
+         position: 1
+    in: { runtime: record_runtime/runtime }
+    out: [ runtime_review ]
+      
+

--- a/v1.0/v1.0/paramref_arguments_self.cwl
+++ b/v1.0/v1.0/paramref_arguments_self.cwl
@@ -1,0 +1,43 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: Workflow
+inputs: []
+outputs:
+  self_review:
+    type: File
+    outputSource: evaluate_self/self_review
+steps:
+  dump_self:
+    run:
+      class: CommandLineTool
+      baseCommand: echo
+      inputs: []
+      arguments:
+       - '{"self":$(self)}'
+      stdout: self.json
+      outputs:
+        self_json: stdout
+    in: []
+    out: [self_json]
+  evaluate_self:
+    run:
+      class: CommandLineTool
+      hints:
+        DockerRequirement:
+          dockerPull: everpeace/curl-jq
+      inputs:
+        self:
+          type: File
+          inputBinding:
+            position: 2
+      stdout: self_review.txt
+      outputs:
+        self_review: stdout
+      baseCommand: jq
+      arguments:
+       - valueFrom: '.self | type == "null"'
+         position: 1
+    in: { self: dump_self/self_json }
+    out: [ self_review ]
+      
+


### PR DESCRIPTION
runtime:
- [x] Cromwell: issue filed https://github.com/broadinstitute/cromwell/issues/3710
- [x] Rabix: passes
- [x] cwltool: passes
- [x] arvados: presumed passing
- ~~cwlexec: didn't pass; needs issue filed https://ci.commonwl.org/job/cwl-spec-pr-cwlexec/14/testReport/junit/conformance_test_v1/0/confirm_that_$runtime_is_available_to_parameter_references_in_arguments/~~

self:
- ~~Cromwell: passes~~
- [x] cwltool: does not pass; issue at https://github.com/common-workflow-language/cwltool/issues/781
- [ ] arvados: 
- ~~cwlexec: didn't pass, needs issued filed https://ci.commonwl.org/job/cwl-spec-pr-cwlexec/15/testReport/junit/conformance_test_v1/0/confirm_that_$self_is_available_and_set_to_null_in_arguments/~~

inputs:
- ~~Cromwell:  issue filed broadinstitute/cromwell#3710~~
- [x] Rabix: passes
- [x] cwltool: passes
- [ ] arvados: 
- ~~cwlexec: didn't pass `The variable type of the field [a_double] is not valid, "double" is required.` Needs issue filed https://ci.commonwl.org/job/cwl-spec-pr-cwlexec/15/testReport/junit/conformance_test_v1/0/confirm_that_$inputs_is_available_to_parameter_references_in_arguments/~~