### PR TITLE
Add optional 'name' fields to certain schema classes.

### DIFF
--- a/v1.0/CommandLineTool.yml
+++ b/v1.0/CommandLineTool.yml
@@ -352,7 +352,10 @@ $graph:
   specialize:
     - specializeFrom: OutputRecordField
       specializeTo: CommandOutputRecordField
-
+  fields:
+    - name: name
+      type: string?
+      jsonldPredicate: "@id"
 
 - name: CommandOutputEnumSchema
   type: record

--- a/v1.0/Process.yml
+++ b/v1.0/Process.yml
@@ -562,12 +562,19 @@ $graph:
   specialize:
     - specializeFrom: "sld:RecordField"
       specializeTo: InputRecordField
+  fields:
+    - name: name
+      type: string?
+      jsonldPredicate: "@id"
 
 
 - name: InputEnumSchema
   type: record
   extends: ["sld:EnumSchema", InputSchema]
   fields:
+    - name: name
+      type: string?
+      jsonldPredicate: "@id"
     - name: inputBinding
       type: InputBinding?
       jsonldPredicate: "cwl:inputBinding"


### PR DESCRIPTION
Fixes historical mistake where Avro required a 'name' field but the
formal CWL schema didn't provide for one, but schema-salad ignored
'name' fields as a special case to avoid validation errors.