### PR TITLE
Update cat4-tool.cwl

### DIFF
--- a/v1.0/v1.0/cat4-tool.cwl
+++ b/v1.0/v1.0/cat4-tool.cwl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
 cwlVersion: v1.0
-doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
+doc: "Print the contents of a file to stdout using 'cat' running in a docker container if docker is available."
 hints:
   DockerRequirement:
     dockerPull: debian:stretch-slim


### PR DESCRIPTION
if always using docker, it must be `requirements` instead of `hints`