### PR TITLE
Add id number to conformance test

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -6,6 +6,7 @@
       example_human_Illumina.pe_1.fastq,
       example_human_Illumina.pe_2.fastq]
   label: cl_basic_generation
+  id: 1
   doc: General test of command line generation
   tags: [ required, command_line_tool ]
 
@@ -17,6 +18,7 @@
   job: v1.0/bwa-mem-job.json
   tool: v1.0/binding-test.cwl
   label: nested_prefixes_arrays
+  id: 2
   doc: Test nested prefixes with arrays
   tags: [ required, command_line_tool ]
 
@@ -27,6 +29,7 @@
   job: v1.0/tmap-job.json
   tool: v1.0/tmap-tool.cwl
   label: nested_cl_bindings
+  id: 3
   doc: Test nested command line bindings
   tags: [ schema_def, command_line_tool ]
 
@@ -35,6 +38,7 @@
   job: v1.0/cat-job.json
   tool: v1.0/cat1-testcli.cwl
   label: cl_optional_inputs_missing
+  id: 4
   doc: Test command line with optional input (missing)
   tags: [ required, command_line_tool ]
 
@@ -43,6 +47,7 @@
   job: v1.0/cat-n-job.json
   tool: v1.0/cat1-testcli.cwl
   label: cl_optional_bindings_provided
+  id: 5
   doc: Test command line with optional input (provided)
   tags: [ required, command_line_tool ]
 
@@ -56,6 +61,7 @@
   job: v1.0/cat-job.json
   tool: v1.0/template-tool.cwl
   label: initworkdir_expreng_requirements
+  id: 6
   doc: Test InitialWorkDirRequirement ExpressionEngineRequirement.engineConfig feature
   tags: [ initial_work_dir, inline_javascript, command_line_tool ]
 
@@ -68,6 +74,7 @@
       size: 13
   tool: v1.0/cat3-tool.cwl
   label: stdout_redirect_docker
+  id: 7
   doc: Test command execution in Docker with stdout redirection
   tags: [ required, command_line_tool ]
 
@@ -80,6 +87,7 @@
       location: Any
       size: 13
   label: stdout_redirect_shortcut_docker
+  id: 8
   doc: Test command execution in Docker with shortcut stdout redirection
   tags: [ required, command_line_tool ]
 
@@ -92,12 +100,14 @@
       size: 13
   tool: v1.0/cat3-tool-mediumcut.cwl
   label: stdout_redirect_mediumcut_docker
+  id: 9
   doc: Test command execution in Docker with mediumcut stdout redirection
   tags: [ required, command_line_tool ]
 
 - job: v1.0/empty.json
   tool: v1.0/stderr.cwl
   label: stderr_redirect
+  id: 10
   doc: Test command line with stderr redirection
   output:
     output_file:
@@ -110,6 +120,7 @@
 - job: v1.0/empty.json
   tool: v1.0/stderr-shortcut.cwl
   label: stderr_redirect_shortcut
+  id: 11
   doc: Test command line with stderr redirection, brief syntax
   output:
     output_file:
@@ -128,6 +139,7 @@
   job: v1.0/empty.json
   tool: v1.0/stderr-mediumcut.cwl
   label: stderr_redirect_mediumcut
+  id: 12
   doc: Test command line with stderr redirection, named brief syntax
   tags: [ shell_command, command_line_tool ]
 
@@ -140,6 +152,7 @@
       size: 13
   tool: v1.0/cat4-tool.cwl
   label: stdinout_redirect_docker
+  id: 13
   doc: Test command execution in Docker with stdin and stdout redirection
   tags: [ required, command_line_tool ]
 
@@ -148,6 +161,7 @@
   output:
     output: 1
   label: expression_any
+  id: 14
   doc: Test default usage of Any in expressions.
   tags: [ inline_javascript, expression_tool ]
 
@@ -156,6 +170,7 @@
   output:
     output: 1
   label: expression_any_null
+  id: 15
   doc: Test explicitly passing null to Any type inputs with default values.
   tags: [ inline_javascript, expression_tool ]
 
@@ -164,6 +179,7 @@
   output:
     output: 2
   label: expression_any_string
+  id: 16
   doc: Testing the string 'null' does not trip up an Any with a default value.
   tags: [ inline_javascript, expression_tool ]
 
@@ -171,6 +187,7 @@
   tool: v1.0/null-expression2-tool.cwl
   should_fail: true
   label: expression_any_nodefaultany
+  id: 17
   doc: Test Any without defaults cannot be unspecified.
   tags: [ inline_javascript, expression_tool ]
 
@@ -178,6 +195,7 @@
   tool: v1.0/null-expression2-tool.cwl
   should_fail: true
   label: expression_any_null_nodefaultany
+  id: 18
   doc: Test explicitly passing null to Any type without a default value.
   tags: [ inline_javascript, expression_tool ]
 
@@ -186,6 +204,7 @@
   output:
     output: 2
   label: expression_any_nullstring_nodefaultany
+  id: 19
   doc: Testing the string 'null' does not trip up an Any without a default value.
   tags: [ inline_javascript, expression_tool ]
 
@@ -196,6 +215,7 @@
     output2: ["foo", "bar"]
     output3: hello
   label: any_outputSource_compatibility
+  id: 20
   doc: Testing Any type compatibility in outputSource
   tags: [ required, workflow ]
 
@@ -208,6 +228,7 @@
       size: 13
   tool: v1.0/cat-tool.cwl
   label: stdinout_redirect
+  id: 21
   doc: Test command execution in with stdin and stdout redirection
   tags: [ required, command_line_tool ]
 
@@ -215,6 +236,7 @@
   output: {output: 42}
   tool: v1.0/parseInt-tool.cwl
   label: expression_parseint
+  id: 22
   doc: Test ExpressionTool with Docker-based expression engine
   tags: [ inline_javascript, expression_tool ]
 
@@ -222,6 +244,7 @@
   output: {output: 16}
   tool: v1.0/wc2-tool.cwl
   label: expression_outputEval
+  id: 23
   doc: Test outputEval to transform output
   tags: [ inline_javascript, command_line_tool ]
 
@@ -229,6 +252,7 @@
   output: {count_output: 16}
   tool: v1.0/count-lines1-wf.cwl
   label: wf_wc_parseInt
+  id: 24
   doc: Test two step workflow with imported tools
   tags: [ inline_javascript, workflow ]
 
@@ -236,6 +260,7 @@
   output: {count_output: 16}
   tool: v1.0/count-lines2-wf.cwl
   label: wf_wc_expressiontool
+  id: 25
   doc: Test two step workflow with inline tools
   tags: [ inline_javascript, workflow ]
 
@@ -244,6 +269,7 @@
     count_output: [16, 1]
   tool: v1.0/count-lines3-wf.cwl
   label: wf_wc_scatter
+  id: 26
   doc: Test single step workflow with Scatter step
   tags: [ scatter, inline_javascript, workflow ]
 
@@ -252,6 +278,7 @@
     count_output: [16, 1]
   tool: v1.0/count-lines4-wf.cwl
   label: wf_wc_scatter_multiple_merge
+  id: 27
   doc: |
     Test single step workflow with Scatter step and two data links connected to
     same input, default merge behavior
@@ -262,6 +289,7 @@
     count_output: [32, 2]
   tool: v1.0/count-lines6-wf.cwl
   label: wf_wc_scatter_multiple_nested
+  id: 28
   doc: |
     Test single step workflow with Scatter step and two data links connected to
     same input, nested merge behavior
@@ -272,6 +300,7 @@
     count_output: 34
   tool: v1.0/count-lines7-wf.cwl
   label: wf_wc_scatter_multiple_flattened
+  id: 29
   doc: |
     Test single step workflow with Scatter step and two data links connected to
     same input, flattened merge behavior
@@ -282,6 +311,7 @@
     count_output: 32
   tool: v1.0/count-lines13-wf.cwl
   label: wf_wc_nomultiple
+  id: 30
   doc: |
     Test that no MultipleInputFeatureRequirement is necessary when
     workflow step source is a single-item list
@@ -291,6 +321,7 @@
   output: {count_output: 1}
   tool: v1.0/count-lines5-wf.cwl
   label: wf_input_default_missing
+  id: 31
   doc: Test workflow with default value for input parameter (missing)
   tags: [ inline_javascript, workflow ]
 
@@ -298,6 +329,7 @@
   output: {count_output: 16}
   tool: v1.0/count-lines5-wf.cwl
   label: wf_input_default_provided
+  id: 32
   doc: Test workflow with default value for input parameter (provided)
   tags: [ inline_javacscript, workflow ]
 
@@ -305,6 +337,7 @@
   output: {default_output: workflow_default}
   tool: v1.0/echo-wf-default.cwl
   label: wf_default_tool_default
+  id: 33
   doc: Test that workflow defaults override tool defaults
   tags: [ required, workflow ]
 
@@ -317,6 +350,7 @@
       size: 15
   tool: v1.0/env-tool1.cwl
   label: envvar_req
+  id: 34
   doc: Test EnvVarRequirement
   tags: [ env_var, command_line_tool ]
 
@@ -325,6 +359,7 @@
     out: ["foo one", "foo two", "foo three", "foo four"]
   tool: v1.0/scatter-wf1.cwl
   label: wf_scatter_single_param
+  id: 35
   doc: Test workflow scatter with single scatter parameter
   tags: [ scatter, workflow ]
 
@@ -333,6 +368,7 @@
     out: [["foo one three", "foo one four"], ["foo two three", "foo two four"]]
   tool: v1.0/scatter-wf2.cwl
   label: wf_scatter_two_nested_crossproduct
+  id: 36
   doc: Test workflow scatter with two scatter parameters and nested_crossproduct join method
   tags: [ scatter, workflow ]
 
@@ -341,6 +377,7 @@
     out: ["foo one three", "foo one four", "foo two three", "foo two four"]
   tool: "v1.0/scatter-wf3.cwl#main"
   label: wf_scatter_two_flat_crossproduct
+  id: 37
   doc: Test workflow scatter with two scatter parameters and flat_crossproduct join method
   tags: [ scatter, workflow ]
 
@@ -349,6 +386,7 @@
     out: ["foo one three", "foo two four"]
   tool: "v1.0/scatter-wf4.cwl#main"
   label: wf_scatter_two_dotproduct
+  id: 38
   doc: Test workflow scatter with two scatter parameters and dotproduct join method
   tags: [ scatter, workflow ]
 
@@ -357,6 +395,7 @@
     out: []
   tool: v1.0/scatter-wf1.cwl
   label: wf_scatter_emptylist
+  id: 39
   doc: Test workflow scatter with single empty list parameter
   tags: [ scatter, workflow ]
 
@@ -365,6 +404,7 @@
     out: [[], []]
   tool: v1.0/scatter-wf2.cwl
   label: wf_scatter_nested_crossproduct_secondempty
+  id: 40
   doc: Test workflow scatter with two scatter parameters and nested_crossproduct join method with second list empty
   tags: [ scatter, workflow ]
 
@@ -373,6 +413,7 @@
     out: []
   tool: "v1.0/scatter-wf3.cwl#main"
   label: wf_scatter_nested_crossproduct_firstempty
+  id: 41
   doc: Test workflow scatter with two scatter parameters and nested_crossproduct join method with first list empty
   tags: [ scatter, workflow ]
 
@@ -381,6 +422,7 @@
     out: []
   tool: "v1.0/scatter-wf3.cwl#main"
   label: wf_scatter_flat_crossproduct_oneempty
+  id: 42
   doc: Test workflow scatter with two scatter parameters, one of which is empty and flat_crossproduct join method
   tags: [ scatter, workflow ]
 
@@ -389,6 +431,7 @@
     out: []
   tool: "v1.0/scatter-wf4.cwl#main"
   label: wf_scatter_dotproduct_twoempty
+  id: 43
   doc: Test workflow scatter with two empty scatter parameters and dotproduct join method
   tags: [ scatter, workflow ]
 
@@ -397,6 +440,7 @@
   output:
     {"out": "hello test env\n"}
   label: any_input_param
+  id: 44
   doc: Test Any type input parameter
   tags: [ required, command_line_tool ]
 
@@ -404,6 +448,7 @@
   output: {count_output: 16}
   tool: v1.0/count-lines8-wf.cwl
   label: nested_workflow
+  id: 45
   doc: Test nested workflow
   tags: [ subworkflow, workflow ]
 
@@ -416,6 +461,7 @@
       size: 15
   tool: v1.0/env-wf1.cwl
   label: requirement_priority
+  id: 46
   doc: Test requirement priority
   tags: [ env_var, workflow ]
 
@@ -428,6 +474,7 @@
       size: 9
   tool: v1.0/env-wf2.cwl
   label: requirement_override_hints
+  id: 47
   doc: Test requirements override hints
   tags: [ env_var, workflow ]
 
@@ -440,6 +487,7 @@
       size: 9
   tool: v1.0/env-wf3.cwl
   label: requirement_workflow_steps
+  id: 48
   doc: Test requirements on workflow steps
   tags: [ env_var, workflow ]
 
@@ -447,6 +495,7 @@
   output: {count_output: 16}
   tool: v1.0/count-lines9-wf.cwl
   label: step_input_default_value
+  id: 49
   doc: Test default value on step input parameter
   tags: [ inline_javascript, workflow ]
 
@@ -454,6 +503,7 @@
   output: {count_output: 16}
   tool: v1.0/count-lines11-wf.cwl
   label: step_input_default_value_nosource
+  id: 50
   doc: Test use default value on step input parameter with empty source
   tags: [ inline_javascript, workflow ]
 
@@ -461,6 +511,7 @@
   output: {count_output: 16}
   tool: v1.0/count-lines11-wf.cwl
   label: step_input_default_value_nullsource
+  id: 51
   doc: Test use default value on step input parameter with null source
   tags: [ inline_javascript, workflow ]
 
@@ -468,6 +519,7 @@
   output: {count_output: 1}
   tool: v1.0/count-lines11-wf.cwl
   label: step_input_default_value_overriden
+  id: 52
   doc: Test default value on step input parameter overridden by provided source
   tags: [ inline_javascript, workflow ]
 
@@ -480,6 +532,7 @@
       size: 1111
   tool: v1.0/revsort.cwl
   label: wf_simple
+  id: 53
   doc: Test simple workflow
   tags: [ required, workflow ]
 
@@ -492,6 +545,7 @@
       size: 13
   tool: v1.0/cat5-tool.cwl
   label: hints_unknown_ignored
+  id: 54
   doc: Test unknown hints are ignored.
   tags: [ required, command_line_tool ]
 
@@ -571,6 +625,7 @@
     }
   tool: "v1.0/search.cwl#main"
   label: initial_workdir_secondary_files_expr
+  id: 55
   doc: |
     Test InitialWorkDirRequirement linking input files and capturing secondaryFiles
     on input and output. Also tests the use of a variety of parameter references
@@ -586,6 +641,7 @@
       size: 1111
   tool: v1.0/rename.cwl
   label: rename
+  id: 56
   doc: |
     Test InitialWorkDirRequirement with expression in filename.
   tags: [ initial_work_dir, command_line_tool ]
@@ -599,6 +655,7 @@
         size: 16
   tool: v1.0/iwdr-entry.cwl
   label: initial_workdir_trailingnl
+  id: 57
   doc: Test if trailing newline is present in file entry in InitialWorkDir
   tags: [ initial_work_dir, command_line_tool ]
 
@@ -607,6 +664,7 @@
     output: 16
   tool: v1.0/wc4-tool.cwl
   label: inline_expressions
+  id: 58
   doc: |
     Test inline expressions
   tags: [ inline_javascript, command_line_tool ]
@@ -620,6 +678,7 @@
         checksum: "sha1$f12e6cfe70f3253f70b0dbde17c692e7fb0f1e5e"
   tool: v1.0/schemadef-tool.cwl
   label: schemadef_req_tool_param
+  id: 59
   doc: |
     Test SchemaDefRequirement definition used in tool parameter
   tags: [ schema_def, command_line_tool ]
@@ -633,6 +692,7 @@
         checksum: "sha1$f12e6cfe70f3253f70b0dbde17c692e7fb0f1e5e"
   tool: v1.0/schemadef-wf.cwl
   label: schemadef_req_wf_param
+  id: 60
   doc: |
     Test SchemaDefRequirement definition used in workflow parameter
   tags: [ schema_def, workflow ]
@@ -712,6 +772,7 @@
     }
   tool: v1.0/params.cwl
   label: param_evaluation_noexpr
+  id: 61
   doc: |
     Test parameter evaluation, no support for JS expressions
   tags: [ required, command_line_tool ]
@@ -791,6 +852,7 @@
     }
   tool: v1.0/params2.cwl
   label: param_evaluation_expr
+  id: 62
   doc: |
     Test parameter evaluation, with support for JS expressions
   tags: [ inline_javascript, command_line_tool ]
@@ -799,6 +861,7 @@
   job: v1.0/cat-job.json
   tool: v1.0/metadata.cwl
   label: metadata
+  id: 63
   doc: Test metadata
   tags: [ required ]
 
@@ -812,6 +875,7 @@
         "checksum": "sha1$97fe1b50b4582cebc7d853796ebd62e3e163aa3f"
   tool: v1.0/formattest.cwl
   label: format_checking
+  id: 64
   doc: |
     Test simple format checking.
   tags: [ required, command_line_tool ]
@@ -826,6 +890,7 @@
         "checksum": "sha1$971d88faeda85a796752ecf752b7e2e34f1337ce"
   tool: v1.0/formattest2.cwl
   label: format_checking_subclass
+  id: 65
   doc: |
     Test format checking against ontology using subclassOf.
   tags: [ required, command_line_tool ]
@@ -840,6 +905,7 @@
         "checksum": "sha1$971d88faeda85a796752ecf752b7e2e34f1337ce"
   tool: v1.0/formattest3.cwl
   label: format_checking_equivalentclass
+  id: 66
   doc: |
     Test format checking against ontology using equivalentClass.
   tags: [ required, command_line_tool ]
@@ -854,6 +920,7 @@
         class: "File"
         checksum: "sha1$47a013e660d408619d894b20806b1d5086aab03b"
   label: output_secondaryfile_optional
+  id: 67
   doc: |
     Test optional output file and optional secondaryFile on output.
   tags: [ docker, command_line_tool ]
@@ -864,6 +931,7 @@
     out: "\n"
   tool: v1.0/vf-concat.cwl
   label: valuefrom_ignored_null
+  id: 68
   doc: Test that valueFrom is ignored when the parameter is null
   tags: [ inline_javascript, command_line_tool ]
 
@@ -872,6 +940,7 @@
     out: "a string\n"
   tool: v1.0/vf-concat.cwl
   label: valuefrom_secondexpr_ignored
+  id: 69
   doc: Test that second expression in concatenated valueFrom is not ignored
   tags: [ inline_javascript, command_line_tool ]
 
@@ -879,6 +948,7 @@
   output: {count_output: 16}
   tool: v1.0/step-valuefrom-wf.cwl
   label: valuefrom_wf_step
+  id: 70
   doc: Test valueFrom on workflow step.
   tags: [ step_input, inline_javascript, workflow ]
 
@@ -886,6 +956,7 @@
   output: {val: "3\n"}
   tool: v1.0/step-valuefrom2-wf.cwl
   label: valuefrom_wf_step_multiple
+  id: 71
   doc: Test valueFrom on workflow step with multiple sources
   tags: [ step_input, inline_javascript, multiple_input, workflow ]
 
@@ -893,6 +964,7 @@
   output: {val: "3\n"}
   tool: v1.0/step-valuefrom3-wf.cwl
   label: valuefrom_wf_step_other
+  id: 72
   doc: Test valueFrom on workflow step referencing other inputs
   tags: [ step_input, inline_javascript, workflow ]
 
@@ -914,6 +986,7 @@
     }
   tool: v1.0/record-output.cwl
   label: record_output_binding
+  id: 73
   doc: Test record type output binding.
   tags: [ shell_command, command_line_tool ]
 
@@ -928,6 +1001,7 @@
   }
   tool: v1.0/test-cwl-out.cwl
   label: docker_json_output_path
+  id: 74
   doc: |
     Test support for reading cwl.output.json when running in a Docker container
     and just 'path' is provided.
@@ -944,6 +1018,7 @@
   }
   tool: v1.0/test-cwl-out2.cwl
   label: docker_json_output_location
+  id: 75
   doc: |
     Test support for reading cwl.output.json when running in a Docker container
     and just 'location' is provided.
@@ -971,6 +1046,7 @@
     }]
   tool: v1.0/glob-expr-list.cwl
   label: multiple_glob_expr_list
+  id: 76
   doc: Test support for returning multiple glob patterns from expression
   tags: [ required, command_line_tool ]
 
@@ -979,6 +1055,7 @@
     out: ["foo one one", "foo one two", "foo one three", "foo one four"]
   tool: v1.0/scatter-valuefrom-wf1.cwl
   label: wf_scatter_oneparam_valuefrom
+  id: 77
   doc: Test workflow scatter with single scatter parameter and two valueFrom on step input (first and current el)
   tags: [ scatter, step_input, workflow ]
 
@@ -987,6 +1064,7 @@
     out: [["foo one one three", "foo one one four"], ["foo one two three", "foo one two four"]]
   tool: v1.0/scatter-valuefrom-wf2.cwl
   label: wf_scatter_twoparam_nested_crossproduct_valuefrom
+  id: 78
   doc: Test workflow scatter with two scatter parameters and nested_crossproduct join method and valueFrom on step input
   tags: [ scatter, step_input, workflow ]
 
@@ -995,6 +1073,7 @@
     out: ["foo one one three", "foo one one four", "foo one two three", "foo one two four"]
   tool: "v1.0/scatter-valuefrom-wf3.cwl#main"
   label: wf_scatter_twoparam_flat_crossproduct_valuefrom
+  id: 79
   doc: Test workflow scatter with two scatter parameters and flat_crossproduct join method and valueFrom on step input
   tags: [ scatter, step_input, workflow ]
 
@@ -1003,6 +1082,7 @@
     out: ["foo one one three", "foo one two four"]
   tool: "v1.0/scatter-valuefrom-wf4.cwl#main"
   label: wf_scatter_twoparam_dotproduct_valuefrom
+  id: 80
   doc: Test workflow scatter with two scatter parameters and dotproduct join method and valueFrom on step input
   tags: [ scatter, step_input, workflow ]
 
@@ -1011,12 +1091,14 @@
     out: ["foo one one", "foo two two", "foo three three", "foo four four"]
   tool: v1.0/scatter-valuefrom-wf5.cwl
   label: wf_scatter_oneparam_valuefrom_twice_current_el
+  id: 81
   doc: Test workflow scatter with single scatter parameter and two valueFrom on step input (current el twice)
   tags: [ scatter, step_input, workflow ]
 
 - job: v1.0/scatter-valuefrom-job3.json
   tool: v1.0/scatter-valuefrom-wf6.cwl
   label: wf_scatter_oneparam_valueFrom
+  id: 82
   doc: Test valueFrom eval on scattered input parameter
   output:
     out_message: [
@@ -1046,6 +1128,7 @@
   }
   tool: "v1.0/conflict-wf.cwl#collision"
   label: wf_two_inputfiles_namecollision
+  id: 83
   doc: Test workflow two input files with same name.
   tags: [ required, workflow ]
 
@@ -1059,6 +1142,7 @@
     }
   tool: v1.0/dir.cwl
   label: directory_input_param_ref
+  id: 84
   doc: Test directory input with parameter reference
   tags: [ shell_command, command_line_tool ]
 
@@ -1072,6 +1156,7 @@
     }
   tool: v1.0/dir2.cwl
   label: directory_input_docker
+  id: 85
   doc: Test directory input in Docker
   tags: [ required, command_line_tool ]
 
@@ -1096,6 +1181,7 @@
     }
   tool: v1.0/dir3.cwl
   label: directory_output
+  id: 86
   doc: Test directory output
   tags: [ required, command_line_tool ]
 
@@ -1110,6 +1196,7 @@
   }
   tool: v1.0/dir4.cwl
   label: directory_secondaryfiles
+  id: 87
   doc: Test directories in secondaryFiles
   tags: [ shell_command, command_line_tool ]
 
@@ -1124,6 +1211,7 @@
   }
   tool: v1.0/dir5.cwl
   label: dynamic_initial_workdir
+  id: 88
   doc: Test dynamic initial work dir
   tags: [ shell_command, initial_work_dir, command_line_tool ]
 
@@ -1138,6 +1226,7 @@
   }
   tool: v1.0/stagefile.cwl
   label: writable_stagedfiles
+  id: 89
   doc: Test writable staged files.
   tags: [ initial_work_dir, command_line_tool ]
 
@@ -1150,6 +1239,7 @@
       size: 18
   tool: v1.0/cat3-tool.cwl
   label: input_file_literal
+  id: 90
   doc: Test file literal as input
   tags: [ required, command_line_tool ]
 
@@ -1162,6 +1252,7 @@
         size: 0
   tool: v1.0/linkfile.cwl
   label: initial_workdir_expr
+  id: 91
   doc: Test expression in InitialWorkDir listing
   tags: [ initial_work_dir, command_line_tool ]
 
@@ -1174,6 +1265,7 @@
         size: 21
   tool: v1.0/nameroot.cwl
   label: nameroot_nameext_stdout_expr
+  id: 92
   doc: Test nameroot/nameext expression in arguments, stdout
   tags: [ required, command_line_tool ]
 
@@ -1187,6 +1279,7 @@
     }
   tool: v1.0/dir6.cwl
   label: input_dir_inputbinding
+  id: 93
   doc: Test directory input with inputBinding
   tags: [ shell_command, command_line_tool ]
 
@@ -1199,6 +1292,7 @@
         size: 2
   tool: v1.0/nested-array.cwl
   label: cl_gen_arrayofarrays
+  id: 94
   doc: Test command line generation of array-of-arrays
   tags: [ required, command_line_tool ]
 
@@ -1206,6 +1300,7 @@
   output: {}
   tool: v1.0/envvar.cwl
   label: env_home_tmpdir
+  id: 95
   doc: Test $HOME and $TMPDIR are set correctly
   tags: [ shell_command, command_line_tool ]
 
@@ -1213,6 +1308,7 @@
   output: {}
   tool: v1.0/envvar2.cwl
   label: env_home_tmpdir_docker
+  id: 96
   doc: Test $HOME and $TMPDIR are set correctly in Docker
   tags: [ shell_command, command_line_tool ]
 
@@ -1226,6 +1322,7 @@
     }
   tool: "v1.0/js-expr-req-wf.cwl#wf"
   label: expressionlib_tool_wf_override
+  id: 97
   doc: Test that expressionLib requirement of individual tool step overrides expressionLib of workflow.
   tags: [ inline_javascript, workflow ]
 
@@ -1244,6 +1341,7 @@
       "size": 12010
   tool: v1.0/initialworkdirrequirement-docker-out.cwl
   label: initial_workdir_output
+  id: 98
   doc: Test output of InitialWorkDir
   tags: [ docker, initial_work_dir, command_line_tool ]
 
@@ -1251,6 +1349,7 @@
   output: {count_output: 16}
   tool: v1.0/count-lines10-wf.cwl
   label: embedded_subworkflow
+  id: 99
   doc: Test embedded subworkflow
   tags: [ subworkflow, workflow ]
 
@@ -1265,6 +1364,7 @@
   }
   tool: v1.0/docker-array-secondaryfiles.cwl
   label: filesarray_secondaryfiles
+  id: 100
   doc: Test secondaryFiles on array of files.
   tags: [ docker, inline_javascript, shell_command, command_line_tool ]
 
@@ -1291,6 +1391,7 @@
   }
   tool: v1.0/dir7.cwl
   label: exprtool_directory_literal
+  id: 101
   doc: Test directory literal output created by ExpressionTool
   tags: [ inline_javascript, expression_tool ]
 
@@ -1303,6 +1404,7 @@
       size: 19
   tool: v1.0/file-literal-ex.cwl
   label: exprtool_file_literal
+  id: 102
   doc: Test file literal output created by ExpressionTool
   tags: [ inline_javascript, expression_tool ]
 
@@ -1316,6 +1418,7 @@
     }
   tool: v1.0/docker-output-dir.cwl
   label: dockeroutputdir
+  id: 103
   doc: Test dockerOutputDirectory
   tags: [ docker, command_line_tool ]
 
@@ -1328,6 +1431,7 @@
       size: 15
   tool: v1.0/imported-hint.cwl
   label: hints_import
+  id: 104
   doc: Test hints with $import
   tags: [ required, command_line_tool ]
 
@@ -1335,6 +1439,7 @@
   job: v1.0/default_path_job.yml
   tool: v1.0/default_path.cwl
   label: default_path_notfound_warning
+  id: 105
   doc: Test warning instead of error when default path is not found
   tags: [ required, command_line_tool ]
 
@@ -1343,6 +1448,7 @@
   job: v1.0/empty.json
   tool: v1.0/inline-js.cwl
   label: inlinejs_req_expressions
+  id: 106
   doc: Test InlineJavascriptRequirement with multiple expressions in the same tool
   tags: [ inline_javascript, command_line_tool ]
 
@@ -1398,6 +1504,7 @@
       }
   tool: v1.0/recursive-input-directory.cwl
   label: input_dir_recurs_copy_writable
+  id: 107
   doc: Test if a writable input directory is recursively copied and writable
   tags: [ initial_work_dir, shell_command, command_line_tool ]
 
@@ -1406,6 +1513,7 @@
   job: v1.0/empty.json
   tool: v1.0/null-defined.cwl
   label: null_missing_params
+  id: 108
   doc: Test that missing parameters are null (not undefined) in expression
   tags: [ inline_javascript, command_line_tool ]
 
@@ -1414,6 +1522,7 @@
   job: v1.0/cat-job.json
   tool: v1.0/null-defined.cwl
   label: param_notnull_expr
+  id: 109
   doc: Test that provided parameter is not null in expression
   tags: [ inline_javascript, command_line_tool ]
 
@@ -1426,6 +1535,7 @@
       size: 1111
   tool: v1.0/revsort-packed.cwl#main
   label: wf_compound_doc
+  id: 110
   doc: Test compound workflow document
   tags: [ required, workflow ]
 
@@ -1445,6 +1555,7 @@
       path: Any
   tool: v1.0/basename-fields-test.cwl
   label: nameroot_nameext_generated
+  id: 111
   doc: Test that nameroot and nameext are generated from basename at execution time by the runner
   tags: [ step_input_expression, workflow ]
 
@@ -1452,6 +1563,7 @@
   output: {}
   tool: v1.0/initialwork-path.cwl
   label: initialworkpath_output
+  id: 112
   doc: Test that file path in $(inputs) for initialworkdir is in $(outdir).
   tags: [ initial_work_dir, command_line_tool ]
 
@@ -1460,6 +1572,7 @@
     count_output: 34
   tool: v1.0/count-lines12-wf.cwl
   label: wf_scatter_twopar_oneinput_flattenedmerge
+  id: 113
   doc: |
     Test single step workflow with Scatter step and two data links connected to
     same input, flattened merge behavior. Workflow inputs are set as list
@@ -1470,6 +1583,7 @@
     result: 12
   tool: v1.0/sum-wf.cwl
   label: wf_multiplesources_multipletypes
+  id: 114
   doc: Test step input with multiple sources with multiple types
   tags: [ step_input, inline_javascript, multiple_input, workflow ]
 
@@ -1490,6 +1604,7 @@
   }
   tool: v1.0/shellchar.cwl
   label: shelldir_notinterpreted
+  id: 115
   doc: "Test that shell directives are not interpreted."
   tags: [ required, command_line_tool ]
 
@@ -1510,6 +1625,7 @@
   }
   tool: v1.0/shellchar2.cwl
   label: shelldir_quoted
+  id: 116
   doc: "Test that shell directives are quoted."
   tags: [ shell_command, command_line_tool ]
 
@@ -1531,6 +1647,7 @@
     }
   tool: v1.0/writable-dir.cwl
   label: initial_workdir_empty_writable
+  id: 117
   doc: Test empty writable dir with InitialWorkDirRequirement
   tags: [ inline_javascript, initial_work_dir, command_line_tool ]
 
@@ -1552,12 +1669,14 @@
     }
   tool: v1.0/writable-dir-docker.cwl
   label: initial_workdir_empty_writable_docker
+  id: 118
   doc: Test empty writable dir with InitialWorkDirRequirement inside Docker
   tags: [ inline_javascript, initial_work_dir, command_line_tool ]
 
 - job: v1.0/dynresreq-job.yaml
   tool: v1.0/dynresreq.cwl
   label: dynamic_resreq_inputs
+  id: 119
   doc: Test dynamic resource reqs referencing inputs
   output:
      output: {
@@ -1577,10 +1696,12 @@
       size: 18
   tool: v1.0/cat3-nodocker.cwl
   label: fileliteral_input_docker
+  id: 120
   doc: Test file literal as input without Docker
   tags: [ required, command_line_tool ]
 
 - doc: Test that OutputBinding.glob is sorted as specified by POSIX
+  id: 121
   job: v1.0/empty.json
   label: outputbinding_glob_sorted
   tool: v1.0/glob_test.cwl
@@ -1617,6 +1738,7 @@
   tags: [ required, command_line_tool ]
 
 - doc: Test InitialWorkDirRequirement with a nested directory structure from another step
+  id: 122
   job: v1.0/empty.json
   output:
     ya_empty:
@@ -1635,6 +1757,7 @@
   }
   tool: v1.0/bool-empty-inputbinding.cwl
   label: booleanflags_cl_noinputbinding
+  id: 123
   doc: "Test that boolean flags do not appear on command line if inputBinding is empty and not null"
   tags: [ required, command_line_tool ]
 
@@ -1644,18 +1767,21 @@
   }
   tool: v1.0/stage-unprovided-file.cwl
   label: expr_reference_self_noinput
+  id: 124
   doc: Test that expression engine does not fail to evaluate reference to self
        with unprovided input
   tags: [ required, command_line_tool ]
 
 - tool: v1.0/exit-success.cwl
   label: success_codes
+  id: 125
   doc: Test successCodes
   job: v1.0/empty.json
   output: {}
   tags: [ required, command_line_tool ]
 
 - job: v1.0/dynresreq-job.yaml
+  id: 126
   doc: Test simple workflow with a dynamic resource requirement
   tool: v1.0/dynresreq-workflow.cwl
   label: dynamic_resreq_wf
@@ -1674,12 +1800,14 @@
   }
   tool: v1.0/empty-array-input.cwl
   label: cl_empty_array_input
+  id: 127
   doc: "Test that empty array input does not add anything to command line"
   tags: [ required, command_line_tool ]
 
 - job: v1.0/empty.json
   tool: v1.0/steplevel-resreq.cwl
   label: resreq_step_overrides_wf
+  id: 128
   doc: Test that ResourceRequirement on a step level redefines requirement on the workflow level
   output:
      out: {
@@ -1696,12 +1824,14 @@
   }
   tool: v1.0/valueFrom-constant.cwl
   label: valuefrom_constant_overrides_inputs
+  id: 129
   doc: Test valueFrom with constant value overriding provided array inputs
   tags: [ required, command_line_tool ]
 
 - job: v1.0/dynresreq-dir-job.yaml
   tool: v1.0/dynresreq-dir.cwl
   label: dynamic_resreq_filesizes
+  id: 130
   doc: Test dynamic resource reqs referencing the size of Files inside a Directory
   output:
      output: {
@@ -1715,6 +1845,7 @@
 - job: v1.0/empty.json
   tool: v1.0/pass-unconnected.cwl
   label: wf_step_connect_undeclared_param
+  id: 131
   doc: |
     Test that it is not an error to connect a parameter to a workflow
     step, even if the parameter doesn't appear in the `run` process
@@ -1725,6 +1856,7 @@
 - job: v1.0/empty.json
   tool: v1.0/fail-unconnected.cwl
   label: wf_step_access_undeclared_param
+  id: 132
   doc: |
     Test that parameters that don't appear in the `run` process
     inputs are not present in the input object used to run the tool.


### PR DESCRIPTION
Problem:
When develop with conformance test,
developer specify number of test `-n1,2,3`.
There is no number in conformance test.
So it is hard to find specific test.

And if new conformance test is insert between existing tests,
The number is slide , brake CI.

Solution:
Each test has own number.