### PR TITLE
Add conformance test for excess carets in a secondaryFile name

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -1862,3 +1862,18 @@
     inputs are not present in the input object used to run the tool.
   should_fail: true
   tags: [ required, workflow ]
+
+- job: v1.0/secondaryfiles.json
+  tool: v1.0/secondaryfiles-extra-carets.cwl
+  label: secondary_files_extra_carets
+  id: 133
+  doc: |
+    Test that excess carets in a secondaryFile name are ignored.
+  output:
+    out:
+      class: File
+      location: hello.2.txt
+      secondaryFiles:
+      - class: File
+        location: hello.txt
+  tags: [ command_line_tool ]

--- a/v1.0/v1.0/secondaryfiles-extra-carets.cwl
+++ b/v1.0/v1.0/secondaryfiles-extra-carets.cwl
@@ -1,0 +1,15 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: echo
+inputs:
+  in:
+    type: File
+    inputBinding:
+      position: 1
+    secondaryFiles:
+    - ^^^^^^.txt
+outputs:
+  out:
+    type: File
+    outputBinding:
+      outputEval: $(inputs.in)

--- a/v1.0/v1.0/secondaryfiles.json
+++ b/v1.0/v1.0/secondaryfiles.json
@@ -1,0 +1,6 @@
+{
+  "in": {
+    "class": "File",
+    "location": "hello.2.txt"
+  }
+}


### PR DESCRIPTION
Extra carets at the start of a secondaryFile should have no effect on the resulting filename.

See common-workflow-language/cwltool#824.