### PR TITLE
Add description for `self` in WorkflowStepInput when it is in `scatter`

### DIFF
--- a/v1.0/Workflow.yml
+++ b/v1.0/Workflow.yml
@@ -303,7 +303,9 @@ $graph:
 
         The `self` value of in the parameter reference or expression must be
         the value of the parameter(s) specified in the `source` field, or
-        null if there is no `source` field.
+        null if there is no `source` field. When the step is specified in
+        `scatter`, it must be an element of the parameter specified in the
+        `source` field.
 
         The value of `inputs` in the parameter reference or expression must be
         the input object to the workflow step after assigning the `source`

--- a/v1.0/Workflow.yml
+++ b/v1.0/Workflow.yml
@@ -302,10 +302,10 @@ $graph:
         evaluated to yield the actual value to be assiged to the input field.
 
         The `self` value in the parameter reference or expression must be
-        1) `null` if there is no `source` field
-        2) the value of the parameter(s) specified in the `source` field when this
+        1. `null` if there is no `source` field
+        2. the value of the parameter(s) specified in the `source` field when this
         workflow input parameter **is not** specified in this workflow step's `scatter` field.
-        3) an element of the parameter specified in the `source` field when this workflow input 
+        3. an element of the parameter specified in the `source` field when this workflow input 
         parameter **is** specified in this workflow step's `scatter` field.
 
         The value of `inputs` in the parameter reference or expression must be

--- a/v1.0/Workflow.yml
+++ b/v1.0/Workflow.yml
@@ -301,11 +301,12 @@ $graph:
         If `valueFrom` is a parameter reference or expression, it must be
         evaluated to yield the actual value to be assiged to the input field.
 
-        The `self` value of in the parameter reference or expression must be
-        the value of the parameter(s) specified in the `source` field, or
-        null if there is no `source` field. When the step is specified in
-        `scatter`, it must be an element of the parameter specified in the
-        `source` field.
+        The `self` value in the parameter reference or expression must be
+        1) `null` if there is no `source` field
+        2) the value of the parameter(s) specified in the `source` field when this
+        workflow input parameter **is not** specified in this workflow step's `scatter` field.
+        3) an element of the parameter specified in the `source` field when this workflow input 
+        parameter **is** specified in this workflow step's `scatter` field.
 
         The value of `inputs` in the parameter reference or expression must be
         the input object to the workflow step after assigning the `source`


### PR DESCRIPTION
This request adds a description the value of `self` must be an element of the value of `source` field rather than the value of `source` field when the step id is specified in `scatter` field.

It makes easier to understand how `self` must behave in the case of scatter.