### PR TITLE
Allow passing a timeout value to cwltest.

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -17,6 +17,7 @@ Options:
                         FILENAME
   --classname=CLASSNAME In the JUnit XML, tag the results with the given
                         CLASSNAME
+  --timeout=TIMEOUT     cwltest timeout in seconds.
   --verbose             Print the cwltest invocation and pass --verbose to
                         cwltest
 
@@ -34,6 +35,7 @@ COVERAGE="python"
 EXTRA=""
 CLASS=""
 VERBOSE=""
+TIMEOUT=""
 
 while [[ -n "$1" ]]
 do
@@ -64,6 +66,9 @@ do
             ;;
         --verbose)
             VERBOSE=$arg
+            ;;
+        --timeout=*)
+            TIMEOUT=$arg
             ;;
         *=*)
             eval $(echo $arg | cut -d= -f1)=\"$(echo $arg | cut -d= -f2-)\"
@@ -98,7 +103,7 @@ runtest() {
     (cd $DRAFT_DIR
      COMMAND="cwltest --tool $1 \
 	     --test=conformance_test_${DRAFT}.yaml ${CLASS} ${TEST_N} \
-	     ${VERBOSE} ${TEST_L} ${TEST_J} ${ONLY_TOOLS} ${JUNIT_XML} \
+	     ${VERBOSE} ${TEST_L} ${TEST_J} ${ONLY_TOOLS} ${JUNIT_XML} ${TIMEOUT} \
 	     --basedir ${DRAFT_DIR} -- ${EXTRA}"
      if [[ $VERBOSE == "--verbose" ]]; then echo ${COMMAND}; fi
      ${COMMAND}


### PR DESCRIPTION
Allows passing a timeout value to override the default cwltest 10 minute timeout limit. The motivation here is to support a cloud backend where a series of steps may occasionally take longer than 10 minutes due to the vagaries of the cloud but still eventually succeed.