### PR TITLE
Add description about input array is empty

### DIFF
--- a/v1.0/CommandLineTool.yml
+++ b/v1.0/CommandLineTool.yml
@@ -180,6 +180,7 @@ $graph:
           the array into a single string with `itemSeparator` separating the
           items.  Otherwise first add `prefix`, then recursively process
           individual elements.
+          If the array is empty, it does not add anything to command line.
 
       - **object**: Add `prefix` only, and recursively add object fields for
           which `inputBinding` is specified.


### PR DESCRIPTION
`doc` of conformance test 127 (empty-array-input.cwl, empty-array-job.json) says below

```
doc: "Test that empty array input does not add anything to command line"
```

But there is no documentation about this in the spec.
