### PR TITLE
Add check for `location` property to test id 86

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -1164,6 +1164,7 @@
   output:
     "outdir": {
         "class": "Directory",
+        "location": Any,
         "listing": [
             {
               "class": "File",


### PR DESCRIPTION
The [specification](https://www.commonwl.org/v1.0/CommandLineTool.html#Directory) says:
> Directory objects in CommandLineTool output must provide either a `location` URI or a `path` property...

However, the corresponding test id 86 that uses [dir3.cwl](https://github.com/common-workflow-language/common-workflow-language/blob/master/v1.0/v1.0/dir3.cwl) and [dir3-job.yml](https://github.com/common-workflow-language/common-workflow-language/blob/master/v1.0/v1.0/dir3-job.yml) only checks a `listing` property but does not check `location` and `path` properties.

This request fixes this issue by checking the existence of `location` property.
