### PR TITLE
replace "--reverse" with "-r" in sort

### DIFF
--- a/v1.0/v1.0/revsort-packed.cwl
+++ b/v1.0/v1.0/revsort-packed.cwl
@@ -97,7 +97,7 @@
                     "type": "boolean", 
                     "inputBinding": {
                         "position": 1, 
-                        "prefix": "--reverse"
+                        "prefix": "-r"
                     }
                 }, 
                 {


### PR DESCRIPTION
The sort command under alpine /  busybox does not support the double dash argument "--reverse", it only supports "-r". Since "-r" should work in any sort implementation, I am suggesting to change the CommandLineTool sorttool.cwl/reverse accordingly.