### PR TITLE
add envvar test w/o return code test

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -1862,3 +1862,16 @@
     inputs are not present in the input object used to run the tool.
   should_fail: true
   tags: [ required, workflow ]
+
+- job: v1.0/empty.json
+  output:
+    results:
+       basename: results
+       class: File
+       checksum: "sha1$7d5ca8c0c03e883c56c4eb1ef6f6bb9bccad4d86"
+       size: 8
+  tool: v1.0/envvar3.cwl
+  label: env_home_tmpdir_docker
+  id: 133
+  doc: Test $HOME and $TMPDIR are set correctly in Docker without using return code
+  tags: [ shell_command, command_line_tool ]

--- a/v1.0/v1.0/envvar3.cwl
+++ b/v1.0/v1.0/envvar3.cwl
@@ -1,0 +1,23 @@
+#!/usr/bin/env cwl-runner
+class: CommandLineTool
+cwlVersion: v1.0
+inputs: []
+outputs:
+  results:
+    type: File
+    outputBinding: { glob: results }
+requirements:
+  ShellCommandRequirement: {}
+hints:
+  DockerRequirement:
+    dockerPull: debian:stretch-slim
+arguments:
+  - shellQuote: false
+    valueFrom: |
+      echo HOME=$HOME TMPDIR=$TMPDIR > log
+      if [ "$HOME" = "$(runtime.outdir)" ] && [ "$TMPDIR" = "$(runtime.tmpdir)" ]
+      then
+          echo success > results
+      else
+          echo failure > results
+      fi


### PR DESCRIPTION
Useful for GA4GH TES as it currently does not have a way to express the return code