### PR TITLE
Add description how `Directory` type is handled for inputBinding

### DIFF
--- a/v1.0/CommandLineTool.yml
+++ b/v1.0/CommandLineTool.yml
@@ -176,6 +176,9 @@ $graph:
       - **File**: Add `prefix` and the value of
         [`File.path`](#File) to the command line.
 
+      - **Directory**: Add `prefix` and the value of
+        [`Directory.path`](#Directory) to the command line.
+
       - **array**: If `itemSeparator` is specified, add `prefix` and the join
           the array into a single string with `itemSeparator` separating the
           items.  Otherwise first add `prefix`, then recursively process


### PR DESCRIPTION
The [section 5.1.2 in the spec](https://www.commonwl.org/v1.0/CommandLineTool.html#CommandLineBinding) describes how each parameter is handled according to its type.
However, it lacks how `Directory` type is handled.

This request simply adds how the parameters of `Directory` types are handled.
