### PR TITLE
Fix scatter_embedded_subworkflow conformance test

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -1931,7 +1931,7 @@
 - job: v1.0/count-lines3-job.json
   output:
     count_output: [16, 1]
-  tool: v1.0/count-lines13-wf.cwl
+  tool: v1.0/count-lines18-wf.cwl
   id: 138
   label: scatter_embedded_subworkflow
   doc: Test simple scatter over an embedded subworkflow

--- a/v1.0/v1.0/count-lines18-wf.cwl
+++ b/v1.0/v1.0/count-lines18-wf.cwl
@@ -21,8 +21,6 @@ steps:
     in: {file1: file1}
     out: [count_output]
     scatter: file1
-    in:
-      file1: file1
     run:
       class: Workflow
       inputs:

--- a/v1.0/v1.0/count-lines18-wf.cwl
+++ b/v1.0/v1.0/count-lines18-wf.cwl
@@ -1,0 +1,34 @@
+#!/usr/bin/env cwl-runner
+class: Workflow
+cwlVersion: v1.0
+
+inputs:
+    file1:
+      type: File[]
+
+outputs:
+  count_output:
+    type: int[]
+    outputSource: step1/count_output
+
+requirements:
+  ScatterFeatureRequirement: {}
+  SubworkflowFeatureRequirement: {}
+  MultipleInputFeatureRequirement: {}
+
+steps:
+  step1:
+    in: {file1: file1}
+    out: [count_output]
+    scatter: file1
+    in:
+      file1: file1
+    run:
+      class: Workflow
+      inputs:
+        file1: File
+      outputs:
+        count_output: {type: int, outputSource: step2/output}
+      steps:
+        step1: {run: wc-tool.cwl, in: {file1: file1}, out: [output]}
+        step2: {run: parseInt-tool.cwl, in: {file1: step1/output}, out: [output]}


### PR DESCRIPTION
Looks like there was a merge conflict over count-lines13-wf.cwl and it
was resolved incorrectly.  Added count-lines18-wf.cwl which presumably
tests what the test was supposed to test.