### PR TITLE
Use `label` field instead of `name` field in the conformance test 143

### DIFF
--- a/v1.0/v1.0/record-output-wf.cwl
+++ b/v1.0/v1.0/record-output-wf.cwl
@@ -16,7 +16,7 @@ inputs:
 outputs:
   orec:
     type:
-      name: orec
+      label: orec
       type: record
       fields:
       - name: ofoo

--- a/v1.0/v1.0/record-output-wf.cwl
+++ b/v1.0/v1.0/record-output-wf.cwl
@@ -16,7 +16,6 @@ inputs:
 outputs:
   orec:
     type:
-      label: orec
       type: record
       fields:
       - name: ofoo


### PR DESCRIPTION
The [spec](https://www.commonwl.org/v1.0/Workflow.html#OutputRecordSchema) says that `OutputRecordSchema` consists of `type`, `fields` and `label` fields.

However, the conformance test 143 (consists of [record-output-wf.cwl](https://github.com/common-workflow-language/common-workflow-language/blob/master/v1.0/v1.0/record-output-wf.cwl) and [record-output-job.json](https://github.com/common-workflow-language/common-workflow-language/blob/master/v1.0/v1.0/record-output-job.json)) uses an invalid `OutputRecordSchema` object that includes [`name` field](https://github.com/common-workflow-language/common-workflow-language/blob/master/v1.0/v1.0/record-output-wf.cwl#L19).

This request fixes this issue by simply replacing `name` with `label` field.