### PR TITLE
Fix id for schema-def_anonymous_enum_in_array

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -2585,7 +2585,7 @@
       class: File
       checksum: "sha1$f17c7d81f66e1520fca25b96b90eeeae5bbf08b0"
       size: 39
-  id: 196
+  id: 197
   label: schema-def_anonymous_enum_in_array
   doc: Test an anonymous enum inside an array inside a record, SchemaDefRequirement
   tags: [command_line, schema_def]


### PR DESCRIPTION
This request is to fix `id` field for the test with the label `schema-def_anonymous_enum_in_array`.
Currently its `id` is `196` but it is duplicated with the test with the label `anonymous_enum_in_array`.