### PR TITLE
Replace `command_line` with `command_line_tool` in `tags` field

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -2576,7 +2576,7 @@
   id: 196
   label: anonymous_enum_in_array
   doc: Test an anonymous enum inside an array inside a record
-  tags: [command_line, required]
+  tags: [command_line_tool, required]
 
 - tool: v1.0/anon_enum_inside_array_inside_schemadef.cwl
   job: v1.0/anon_enum_inside_array_inside_schemadef.yml
@@ -2588,5 +2588,5 @@
   id: 197
   label: schema-def_anonymous_enum_in_array
   doc: Test an anonymous enum inside an array inside a record, SchemaDefRequirement
-  tags: [command_line, schema_def]
+  tags: [command_line_tool, schema_def]
 


### PR DESCRIPTION
Tests 196 and 197 are tagged as `command_line` but other tests for `CommandLineTool` uses `command_line_tool` for this purpose (e.g, id 1, 2, 3 and others).
This request just replaces `command_line` with `command_line_tool` in the `tags` field.
