### PR TITLE
Add test for staging array input in a directory

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -2590,3 +2590,15 @@
   doc: Test an anonymous enum inside an array inside a record, SchemaDefRequirement
   tags: [command_line_tool, schema_def]
 
+- job: v1.0/stage_array_in_dir-job.yml
+  output:
+    outfile:
+      checksum: "sha1$327fc7aedf4f6b69a42a7c8b808dc5a7aff61376"
+      size: 1111
+      location: whale.txt
+      class: File
+  tool: v1.0/stage_array_in_dir.cwl
+  label: stage_array_in_dir
+  id: 198
+  doc: Test staging array of files in a subdirectory.
+  tags: [ initial_work_dir, command_line_tool ]

--- a/v1.0/v1.0/stage_array_in_dir-job.yml
+++ b/v1.0/v1.0/stage_array_in_dir-job.yml
@@ -1,0 +1,3 @@
+infiles:
+  - class: File
+    location: whale.txt

--- a/v1.0/v1.0/stage_array_in_dir.cwl
+++ b/v1.0/v1.0/stage_array_in_dir.cwl
@@ -1,0 +1,23 @@
+class: CommandLineTool
+cwlVersion: v1.0
+baseCommand:
+  - ls
+  - staged
+inputs:
+  - id: infiles
+    type: File[]
+outputs:
+  - id: outfile
+    type: File
+    outputBinding:
+      glob: staged/whale.txt
+requirements:
+  - class: InitialWorkDirRequirement
+    listing:
+      - entry: >-
+          ${ return { 'class': 'Directory', 'listing': inputs.infiles,
+          'basename': 'staged'} }
+  - class: InlineJavascriptRequirement
+hints:
+  - class: DockerRequirement
+    dockerPull: 'debian:stretch-slim'


### PR DESCRIPTION
Partially handles https://github.com/common-workflow-language/common-workflow-language/issues/777, just for case that is definitely clear to work in v1.0, when folder name is set as `basename` property