### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -5,11 +5,11 @@ Chilton, John; Heuer, Michael; Kartashov, Andrey; Kern, John; Leehr, Dan;
 Ménager, Hervé; Nedeljkovich, Maya; Scales, Matt; Soiland-Reyes, Stian;
 Stojanovic, Luka (2016): Common Workflow Language, v1.0. Specification,
 Common Workflow Language working group. https://w3id.org/cwl/v1.0/
-https://dx.doi.org/10.6084/m9.figshare.3115156.v2
+https://doi.org/10.6084/m9.figshare.3115156.v2
 
 @data{cwl,
   doi = {10.6084/m9.figshare.3115156.v2},
-  url = {http://dx.doi.org/10.6084/m9.figshare.3115156.v2},
+  url = {https://doi.org/10.6084/m9.figshare.3115156.v2},
   author = {Peter Amstutz; Michael R. Crusoe; Nebojša Tijanić; Brad Chapman;
 John Chilton; Michael Heuer; Andrey Kartashov; John Kern; Dan Leehr;
 Hervé Ménager; Maya Nedeljkovich; Matt Scales; Stian Soiland-Reyes;

--- a/draft-3/README.md
+++ b/draft-3/README.md
@@ -22,4 +22,4 @@ specifies the preprocessing steps that must be applied when loading CWL
 documents and the schema language used to write the above specifications.
 
 If you use the CWL specifications or distribute CWL descriptions with a
-publication you should [cite the standard](https://dx.doi.org/10.6084/m9.figshare.3115156.v1)
+publication you should [cite the standard](https://doi.org/10.6084/m9.figshare.3115156.v1)


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!