### PR TITLE
Add memory hints

### DIFF
--- a/v1.0/v1.0/anon_enum_inside_array.cwl
+++ b/v1.0/v1.0/anon_enum_inside_array.cwl
@@ -1,5 +1,8 @@
 cwlVersion: v1.0
 class: CommandLineTool
+hints:
+  ResourceRequirement:
+    ramMin: 128
 inputs:
   first:
     type:

--- a/v1.0/v1.0/anon_enum_inside_array.cwl
+++ b/v1.0/v1.0/anon_enum_inside_array.cwl
@@ -2,7 +2,7 @@ cwlVersion: v1.0
 class: CommandLineTool
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 inputs:
   first:
     type:

--- a/v1.0/v1.0/anon_enum_inside_array_inside_schemadef.cwl
+++ b/v1.0/v1.0/anon_enum_inside_array_inside_schemadef.cwl
@@ -2,7 +2,7 @@ cwlVersion: v1.0
 class: CommandLineTool
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 requirements:
   SchemaDefRequirement:
     types: 

--- a/v1.0/v1.0/anon_enum_inside_array_inside_schemadef.cwl
+++ b/v1.0/v1.0/anon_enum_inside_array_inside_schemadef.cwl
@@ -1,5 +1,8 @@
 cwlVersion: v1.0
 class: CommandLineTool
+hints:
+  ResourceRequirement:
+    ramMin: 128
 requirements:
   SchemaDefRequirement:
     types: 

--- a/v1.0/v1.0/basename-fields-test.cwl
+++ b/v1.0/v1.0/basename-fields-test.cwl
@@ -4,6 +4,10 @@ class: Workflow
 requirements:
   - class: StepInputExpressionRequirement
 
+hints:
+  ResourceRequirement:
+    ramMin: 128
+
 inputs:
   tool: File
 

--- a/v1.0/v1.0/basename-fields-test.cwl
+++ b/v1.0/v1.0/basename-fields-test.cwl
@@ -6,7 +6,7 @@ requirements:
 
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 
 inputs:
   tool: File

--- a/v1.0/v1.0/binding-test.cwl
+++ b/v1.0/v1.0/binding-test.cwl
@@ -6,7 +6,7 @@ hints:
   - class: DockerRequirement
     dockerPull: python:2-slim
   - class: ResourceRequirement
-    ramMin: 128
+    ramMin: 8
 inputs:
   - id: reference
     type: File

--- a/v1.0/v1.0/binding-test.cwl
+++ b/v1.0/v1.0/binding-test.cwl
@@ -5,6 +5,8 @@ cwlVersion: v1.0
 hints:
   - class: DockerRequirement
     dockerPull: python:2-slim
+  - class: ResourceRequirement
+    ramMin: 128
 inputs:
   - id: reference
     type: File

--- a/v1.0/v1.0/bool-empty-inputbinding.cwl
+++ b/v1.0/v1.0/bool-empty-inputbinding.cwl
@@ -5,7 +5,7 @@ hints:
   - class: DockerRequirement
     dockerPull: python:2-slim
   - class: ResourceRequirement
-    ramMin: 128
+    ramMin: 8
 inputs:
 - id: flag
   type: boolean

--- a/v1.0/v1.0/bool-empty-inputbinding.cwl
+++ b/v1.0/v1.0/bool-empty-inputbinding.cwl
@@ -4,6 +4,8 @@ cwlVersion: v1.0
 hints:
   - class: DockerRequirement
     dockerPull: python:2-slim
+  - class: ResourceRequirement
+    ramMin: 128
 inputs:
 - id: flag
   type: boolean

--- a/v1.0/v1.0/bwa-mem-tool.cwl
+++ b/v1.0/v1.0/bwa-mem-tool.cwl
@@ -7,6 +7,7 @@ class: CommandLineTool
 hints:
   - class: ResourceRequirement
     coresMin: 2
+    ramMin: 128
   - class: DockerRequirement
     dockerPull: python:2-slim
 

--- a/v1.0/v1.0/bwa-mem-tool.cwl
+++ b/v1.0/v1.0/bwa-mem-tool.cwl
@@ -7,7 +7,7 @@ class: CommandLineTool
 hints:
   - class: ResourceRequirement
     coresMin: 2
-    ramMin: 128
+    ramMin: 8
   - class: DockerRequirement
     dockerPull: python:2-slim
 

--- a/v1.0/v1.0/cat-from-dir.cwl
+++ b/v1.0/v1.0/cat-from-dir.cwl
@@ -4,7 +4,7 @@ class: CommandLineTool
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 
 inputs:
   dir1: Directory

--- a/v1.0/v1.0/cat-from-dir.cwl
+++ b/v1.0/v1.0/cat-from-dir.cwl
@@ -2,6 +2,9 @@
 
 class: CommandLineTool
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 
 inputs:
   dir1: Directory

--- a/v1.0/v1.0/cat-tool.cwl
+++ b/v1.0/v1.0/cat-tool.cwl
@@ -4,7 +4,7 @@ class: CommandLineTool
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 
 inputs:
   file1: File

--- a/v1.0/v1.0/cat-tool.cwl
+++ b/v1.0/v1.0/cat-tool.cwl
@@ -2,6 +2,9 @@
 
 class: CommandLineTool
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 
 inputs:
   file1: File

--- a/v1.0/v1.0/cat1-testcli.cwl
+++ b/v1.0/v1.0/cat1-testcli.cwl
@@ -7,6 +7,10 @@
         {
             "class": "DockerRequirement",
             "dockerPull": "python:2-slim"
+        },
+        {
+            "class": "ResourceRequirement",
+            "ramMin": 128
         }
     ],
     "inputs": [

--- a/v1.0/v1.0/cat3-from-dir.cwl
+++ b/v1.0/v1.0/cat3-from-dir.cwl
@@ -1,6 +1,9 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 inputs:
   dir1:
     type: Directory

--- a/v1.0/v1.0/cat3-from-dir.cwl
+++ b/v1.0/v1.0/cat3-from-dir.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 inputs:
   dir1:
     type: Directory

--- a/v1.0/v1.0/cat3-nodocker.cwl
+++ b/v1.0/v1.0/cat3-nodocker.cwl
@@ -2,6 +2,9 @@
 class: CommandLineTool
 cwlVersion: v1.0
 doc: "Print the contents of a file to stdout using 'cat'."
+hints:
+  ResourceRequirement:
+    ramMin: 128
 inputs:
   file1:
     type: File

--- a/v1.0/v1.0/cat3-nodocker.cwl
+++ b/v1.0/v1.0/cat3-nodocker.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 doc: "Print the contents of a file to stdout using 'cat'."
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 inputs:
   file1:
     type: File

--- a/v1.0/v1.0/cat3-tool-docker.cwl
+++ b/v1.0/v1.0/cat3-tool-docker.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 requirements:
   DockerRequirement:
     dockerPull: debian:stretch-slim

--- a/v1.0/v1.0/cat3-tool-docker.cwl
+++ b/v1.0/v1.0/cat3-tool-docker.cwl
@@ -2,6 +2,9 @@
 class: CommandLineTool
 cwlVersion: v1.0
 doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
+hints:
+  ResourceRequirement:
+    ramMin: 128
 requirements:
   DockerRequirement:
     dockerPull: debian:stretch-slim

--- a/v1.0/v1.0/cat3-tool-mediumcut.cwl
+++ b/v1.0/v1.0/cat3-tool-mediumcut.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 requirements:
   DockerRequirement:
     dockerPull: debian:stretch-slim

--- a/v1.0/v1.0/cat3-tool-mediumcut.cwl
+++ b/v1.0/v1.0/cat3-tool-mediumcut.cwl
@@ -2,6 +2,9 @@
 class: CommandLineTool
 cwlVersion: v1.0
 doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
+hints:
+  ResourceRequirement:
+    ramMin: 128
 requirements:
   DockerRequirement:
     dockerPull: debian:stretch-slim

--- a/v1.0/v1.0/cat3-tool-shortcut.cwl
+++ b/v1.0/v1.0/cat3-tool-shortcut.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 requirements:
   DockerRequirement:
     dockerPull: debian:stretch-slim

--- a/v1.0/v1.0/cat3-tool-shortcut.cwl
+++ b/v1.0/v1.0/cat3-tool-shortcut.cwl
@@ -2,6 +2,9 @@
 class: CommandLineTool
 cwlVersion: v1.0
 doc: "Print the contents of a file to stdout using 'cat' running in a docker container."
+hints:
+  ResourceRequirement:
+    ramMin: 128
 requirements:
   DockerRequirement:
     dockerPull: debian:stretch-slim

--- a/v1.0/v1.0/cat3-tool.cwl
+++ b/v1.0/v1.0/cat3-tool.cwl
@@ -6,7 +6,7 @@ hints:
   DockerRequirement:
     dockerPull: debian:stretch-slim
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 inputs:
   file1:
     type: File

--- a/v1.0/v1.0/cat3-tool.cwl
+++ b/v1.0/v1.0/cat3-tool.cwl
@@ -5,6 +5,8 @@ doc: "Print the contents of a file to stdout using 'cat' running in a docker con
 hints:
   DockerRequirement:
     dockerPull: debian:stretch-slim
+  ResourceRequirement:
+    ramMin: 128
 inputs:
   file1:
     type: File

--- a/v1.0/v1.0/cat4-tool.cwl
+++ b/v1.0/v1.0/cat4-tool.cwl
@@ -5,6 +5,8 @@ doc: "Print the contents of a file to stdout using 'cat' running in a docker con
 hints:
   DockerRequirement:
     dockerPull: debian:stretch-slim
+  ResourceRequirement:
+    ramMin: 128
 inputs:
   file1: File
 outputs:

--- a/v1.0/v1.0/cat4-tool.cwl
+++ b/v1.0/v1.0/cat4-tool.cwl
@@ -6,7 +6,7 @@ hints:
   DockerRequirement:
     dockerPull: debian:stretch-slim
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 inputs:
   file1: File
 outputs:

--- a/v1.0/v1.0/cat5-tool.cwl
+++ b/v1.0/v1.0/cat5-tool.cwl
@@ -8,7 +8,7 @@ hints:
   DockerRequirement:
     dockerPull: "debian:stretch-slim"
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
   ex:BlibberBlubberFakeRequirement:
     fakeField: fraggleFroogle
 inputs:

--- a/v1.0/v1.0/cat5-tool.cwl
+++ b/v1.0/v1.0/cat5-tool.cwl
@@ -7,6 +7,8 @@ doc: "Print the contents of a file to stdout using 'cat' running in a docker con
 hints:
   DockerRequirement:
     dockerPull: "debian:stretch-slim"
+  ResourceRequirement:
+    ramMin: 128
   ex:BlibberBlubberFakeRequirement:
     fakeField: fraggleFroogle
 inputs:

--- a/v1.0/v1.0/conflict-wf.cwl
+++ b/v1.0/v1.0/conflict-wf.cwl
@@ -2,6 +2,9 @@ cwlVersion: v1.0
 $graph:
 - id: echo
   class: CommandLineTool
+  hints:
+    ResourceRequirement:
+      ramMin: 128
   inputs:
     text:
       type: string
@@ -18,6 +21,10 @@ $graph:
 
 - id: cat
   class: CommandLineTool
+  hints:
+    ResourceRequirement:
+      ramMin: 128
+
   inputs:
     file1:
       type: File

--- a/v1.0/v1.0/conflict-wf.cwl
+++ b/v1.0/v1.0/conflict-wf.cwl
@@ -4,7 +4,7 @@ $graph:
   class: CommandLineTool
   hints:
     ResourceRequirement:
-      ramMin: 128
+      ramMin: 8
   inputs:
     text:
       type: string
@@ -23,7 +23,7 @@ $graph:
   class: CommandLineTool
   hints:
     ResourceRequirement:
-      ramMin: 128
+      ramMin: 8
 
   inputs:
     file1:

--- a/v1.0/v1.0/default_path.cwl
+++ b/v1.0/v1.0/default_path.cwl
@@ -1,5 +1,8 @@
 cwlVersion: v1.0
 class: CommandLineTool
+hints:
+  ResourceRequirement:
+    ramMin: 128
 inputs:
   - id: "file1"
     type: File

--- a/v1.0/v1.0/default_path.cwl
+++ b/v1.0/v1.0/default_path.cwl
@@ -2,7 +2,7 @@ cwlVersion: v1.0
 class: CommandLineTool
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 inputs:
   - id: "file1"
     type: File

--- a/v1.0/v1.0/dir.cwl
+++ b/v1.0/v1.0/dir.cwl
@@ -2,7 +2,7 @@ class: CommandLineTool
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 requirements:
   - class: ShellCommandRequirement
 inputs:

--- a/v1.0/v1.0/dir.cwl
+++ b/v1.0/v1.0/dir.cwl
@@ -1,5 +1,8 @@
 class: CommandLineTool
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 requirements:
   - class: ShellCommandRequirement
 inputs:

--- a/v1.0/v1.0/dir2.cwl
+++ b/v1.0/v1.0/dir2.cwl
@@ -6,7 +6,7 @@ hints:
   DockerRequirement:
     dockerPull: debian:stretch-slim
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 inputs:
   indir: Directory
 outputs:

--- a/v1.0/v1.0/dir2.cwl
+++ b/v1.0/v1.0/dir2.cwl
@@ -5,6 +5,8 @@ requirements:
 hints:
   DockerRequirement:
     dockerPull: debian:stretch-slim
+  ResourceRequirement:
+    ramMin: 128
 inputs:
   indir: Directory
 outputs:

--- a/v1.0/v1.0/dir3.cwl
+++ b/v1.0/v1.0/dir3.cwl
@@ -2,7 +2,7 @@ class: CommandLineTool
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 baseCommand: [tar, xvf]
 inputs:
   inf:

--- a/v1.0/v1.0/dir3.cwl
+++ b/v1.0/v1.0/dir3.cwl
@@ -1,5 +1,8 @@
 class: CommandLineTool
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 baseCommand: [tar, xvf]
 inputs:
   inf:

--- a/v1.0/v1.0/dir4.cwl
+++ b/v1.0/v1.0/dir4.cwl
@@ -2,7 +2,7 @@ class: CommandLineTool
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 requirements:
   - class: ShellCommandRequirement
 inputs:

--- a/v1.0/v1.0/dir4.cwl
+++ b/v1.0/v1.0/dir4.cwl
@@ -1,5 +1,8 @@
 class: CommandLineTool
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 requirements:
   - class: ShellCommandRequirement
 inputs:

--- a/v1.0/v1.0/dir5.cwl
+++ b/v1.0/v1.0/dir5.cwl
@@ -2,7 +2,7 @@ class: CommandLineTool
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 requirements:
   - class: ShellCommandRequirement
   - class: InitialWorkDirRequirement

--- a/v1.0/v1.0/dir5.cwl
+++ b/v1.0/v1.0/dir5.cwl
@@ -1,5 +1,8 @@
 class: CommandLineTool
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 requirements:
   - class: ShellCommandRequirement
   - class: InitialWorkDirRequirement

--- a/v1.0/v1.0/dir6.cwl
+++ b/v1.0/v1.0/dir6.cwl
@@ -2,7 +2,7 @@ class: CommandLineTool
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 requirements:
   - class: ShellCommandRequirement
 inputs:

--- a/v1.0/v1.0/dir6.cwl
+++ b/v1.0/v1.0/dir6.cwl
@@ -1,5 +1,8 @@
 class: CommandLineTool
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 requirements:
   - class: ShellCommandRequirement
 inputs:

--- a/v1.0/v1.0/docker-array-secondaryfiles.cwl
+++ b/v1.0/v1.0/docker-array-secondaryfiles.cwl
@@ -1,6 +1,9 @@
 #!/usr/bin/env cwl-runner
 
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 
 requirements:
   - class: DockerRequirement

--- a/v1.0/v1.0/docker-array-secondaryfiles.cwl
+++ b/v1.0/v1.0/docker-array-secondaryfiles.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 
 requirements:
   - class: DockerRequirement

--- a/v1.0/v1.0/docker-output-dir.cwl
+++ b/v1.0/v1.0/docker-output-dir.cwl
@@ -1,5 +1,8 @@
 class: CommandLineTool
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 requirements:
   DockerRequirement:
     dockerPull: debian:stretch-slim

--- a/v1.0/v1.0/docker-output-dir.cwl
+++ b/v1.0/v1.0/docker-output-dir.cwl
@@ -2,7 +2,7 @@ class: CommandLineTool
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 requirements:
   DockerRequirement:
     dockerPull: debian:stretch-slim

--- a/v1.0/v1.0/docker-run-cmd.cwl
+++ b/v1.0/v1.0/docker-run-cmd.cwl
@@ -1,5 +1,8 @@
 class: CommandLineTool
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 requirements:
   DockerRequirement:
     dockerPull: bash:4.4.12

--- a/v1.0/v1.0/docker-run-cmd.cwl
+++ b/v1.0/v1.0/docker-run-cmd.cwl
@@ -2,7 +2,7 @@ class: CommandLineTool
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 requirements:
   DockerRequirement:
     dockerPull: bash:4.4.12

--- a/v1.0/v1.0/dynresreq-default.cwl
+++ b/v1.0/v1.0/dynresreq-default.cwl
@@ -4,6 +4,7 @@ cwlVersion: v1.0
 
 requirements:
   ResourceRequirement:
+      ramMin: 128
       coresMin: $(inputs.special_file.size)
       coresMax: $(inputs.special_file.size)
 

--- a/v1.0/v1.0/dynresreq-default.cwl
+++ b/v1.0/v1.0/dynresreq-default.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 
 requirements:
   ResourceRequirement:
-      ramMin: 128
+      ramMin: 8
       coresMin: $(inputs.special_file.size)
       coresMax: $(inputs.special_file.size)
 

--- a/v1.0/v1.0/dynresreq-dir.cwl
+++ b/v1.0/v1.0/dynresreq-dir.cwl
@@ -5,6 +5,7 @@ cwlVersion: v1.0
 requirements:
   InlineJavascriptRequirement: {}
   ResourceRequirement:
+      ramMin: 128
       coresMin: $(inputs.dir.listing[0].size)
       coresMax: $(inputs.dir.listing[0].size)
 

--- a/v1.0/v1.0/dynresreq-dir.cwl
+++ b/v1.0/v1.0/dynresreq-dir.cwl
@@ -5,7 +5,7 @@ cwlVersion: v1.0
 requirements:
   InlineJavascriptRequirement: {}
   ResourceRequirement:
-      ramMin: 128
+      ramMin: 8
       coresMin: $(inputs.dir.listing[0].size)
       coresMax: $(inputs.dir.listing[0].size)
 

--- a/v1.0/v1.0/dynresreq.cwl
+++ b/v1.0/v1.0/dynresreq.cwl
@@ -4,6 +4,7 @@ cwlVersion: v1.0
 
 requirements:
   ResourceRequirement:
+      ramMin: 128
       coresMin: $(inputs.special_file.size)
       coresMax: $(inputs.special_file.size)
 

--- a/v1.0/v1.0/dynresreq.cwl
+++ b/v1.0/v1.0/dynresreq.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 
 requirements:
   ResourceRequirement:
-      ramMin: 128
+      ramMin: 8
       coresMin: $(inputs.special_file.size)
       coresMax: $(inputs.special_file.size)
 

--- a/v1.0/v1.0/echo-file-tool.cwl
+++ b/v1.0/v1.0/echo-file-tool.cwl
@@ -1,5 +1,8 @@
 cwlVersion: v1.0
 class: CommandLineTool
+hints:
+  ResourceRequirement:
+    ramMin: 128
 baseCommand: [echo]
 inputs:
   in:

--- a/v1.0/v1.0/echo-file-tool.cwl
+++ b/v1.0/v1.0/echo-file-tool.cwl
@@ -2,7 +2,7 @@ cwlVersion: v1.0
 class: CommandLineTool
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 baseCommand: [echo]
 inputs:
   in:

--- a/v1.0/v1.0/echo-tool-default.cwl
+++ b/v1.0/v1.0/echo-tool-default.cwl
@@ -4,7 +4,7 @@ class: CommandLineTool
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 inputs:
   in:
     type: string

--- a/v1.0/v1.0/echo-tool-default.cwl
+++ b/v1.0/v1.0/echo-tool-default.cwl
@@ -2,6 +2,9 @@
 
 class: CommandLineTool
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 inputs:
   in:
     type: string

--- a/v1.0/v1.0/echo-tool.cwl
+++ b/v1.0/v1.0/echo-tool.cwl
@@ -2,6 +2,9 @@
 
 class: CommandLineTool
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 inputs:
   in:
     type: Any

--- a/v1.0/v1.0/echo-tool.cwl
+++ b/v1.0/v1.0/echo-tool.cwl
@@ -4,7 +4,7 @@ class: CommandLineTool
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 inputs:
   in:
     type: Any

--- a/v1.0/v1.0/empty-array-input.cwl
+++ b/v1.0/v1.0/empty-array-input.cwl
@@ -5,7 +5,7 @@ class: CommandLineTool
 
 hints:
   - class: ResourceRequirement
-    ramMin: 128
+    ramMin: 8
   - class: DockerRequirement
     dockerPull: python:2-slim
 

--- a/v1.0/v1.0/empty-array-input.cwl
+++ b/v1.0/v1.0/empty-array-input.cwl
@@ -4,6 +4,8 @@ cwlVersion: v1.0
 class: CommandLineTool
 
 hints:
+  - class: ResourceRequirement
+    ramMin: 128
   - class: DockerRequirement
     dockerPull: python:2-slim
 

--- a/v1.0/v1.0/env-tool1.cwl
+++ b/v1.0/v1.0/env-tool1.cwl
@@ -2,7 +2,7 @@ class: CommandLineTool
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 inputs:
   in: string
 outputs:

--- a/v1.0/v1.0/env-tool1.cwl
+++ b/v1.0/v1.0/env-tool1.cwl
@@ -1,5 +1,8 @@
 class: CommandLineTool
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 inputs:
   in: string
 outputs:

--- a/v1.0/v1.0/env-tool2.cwl
+++ b/v1.0/v1.0/env-tool2.cwl
@@ -9,6 +9,8 @@ outputs:
       glob: out
 
 hints:
+  ResourceRequirement:
+    ramMin: 128
   EnvVarRequirement:
     envDef:
       TEST_ENV: $(inputs.in)

--- a/v1.0/v1.0/env-tool2.cwl
+++ b/v1.0/v1.0/env-tool2.cwl
@@ -10,7 +10,7 @@ outputs:
 
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
   EnvVarRequirement:
     envDef:
       TEST_ENV: $(inputs.in)

--- a/v1.0/v1.0/env-wf2.cwl
+++ b/v1.0/v1.0/env-wf2.cwl
@@ -9,7 +9,6 @@ outputs:
     out:
       type: File
       outputSource: step1/out
-
 requirements:
   EnvVarRequirement:
     envDef:

--- a/v1.0/v1.0/envvar.cwl
+++ b/v1.0/v1.0/envvar.cwl
@@ -4,7 +4,7 @@ inputs: []
 outputs: []
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 requirements:
   ShellCommandRequirement: {}
 arguments: [

--- a/v1.0/v1.0/envvar.cwl
+++ b/v1.0/v1.0/envvar.cwl
@@ -2,6 +2,9 @@ class: CommandLineTool
 cwlVersion: v1.0
 inputs: []
 outputs: []
+hints:
+  ResourceRequirement:
+    ramMin: 128
 requirements:
   ShellCommandRequirement: {}
 arguments: [

--- a/v1.0/v1.0/envvar2.cwl
+++ b/v1.0/v1.0/envvar2.cwl
@@ -6,7 +6,7 @@ requirements:
   ShellCommandRequirement: {}
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
   DockerRequirement:
     dockerPull: debian:stretch-slim
 arguments: [

--- a/v1.0/v1.0/envvar2.cwl
+++ b/v1.0/v1.0/envvar2.cwl
@@ -5,6 +5,8 @@ outputs: []
 requirements:
   ShellCommandRequirement: {}
 hints:
+  ResourceRequirement:
+    ramMin: 128
   DockerRequirement:
     dockerPull: debian:stretch-slim
 arguments: [

--- a/v1.0/v1.0/envvar3.cwl
+++ b/v1.0/v1.0/envvar3.cwl
@@ -10,7 +10,7 @@ requirements:
   ShellCommandRequirement: {}
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
   DockerRequirement:
     dockerPull: debian:stretch-slim
 arguments:

--- a/v1.0/v1.0/envvar3.cwl
+++ b/v1.0/v1.0/envvar3.cwl
@@ -9,6 +9,8 @@ outputs:
 requirements:
   ShellCommandRequirement: {}
 hints:
+  ResourceRequirement:
+    ramMin: 128
   DockerRequirement:
     dockerPull: debian:stretch-slim
 arguments:

--- a/v1.0/v1.0/exit-success.cwl
+++ b/v1.0/v1.0/exit-success.cwl
@@ -3,7 +3,7 @@ cwlVersion: v1.0
 class: CommandLineTool
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 
 inputs: []
 baseCommand: "false"

--- a/v1.0/v1.0/exit-success.cwl
+++ b/v1.0/v1.0/exit-success.cwl
@@ -1,6 +1,9 @@
 #!/usr/bin/env cwl-runner
 cwlVersion: v1.0
 class: CommandLineTool
+hints:
+  ResourceRequirement:
+    ramMin: 128
 
 inputs: []
 baseCommand: "false"

--- a/v1.0/v1.0/fail-unspecified-input.cwl
+++ b/v1.0/v1.0/fail-unspecified-input.cwl
@@ -2,7 +2,7 @@ class: CommandLineTool
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 inputs:
   in: string
 outputs:

--- a/v1.0/v1.0/fail-unspecified-input.cwl
+++ b/v1.0/v1.0/fail-unspecified-input.cwl
@@ -1,5 +1,8 @@
 class: CommandLineTool
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 inputs:
   in: string
 outputs:

--- a/v1.0/v1.0/formattest.cwl
+++ b/v1.0/v1.0/formattest.cwl
@@ -5,7 +5,7 @@ class: CommandLineTool
 doc: "Reverse each line using the `rev` command"
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 inputs:
   input:
     type: File

--- a/v1.0/v1.0/formattest.cwl
+++ b/v1.0/v1.0/formattest.cwl
@@ -3,6 +3,9 @@ $namespaces:
 cwlVersion: v1.0
 class: CommandLineTool
 doc: "Reverse each line using the `rev` command"
+hints:
+  ResourceRequirement:
+    ramMin: 128
 inputs:
   input:
     type: File

--- a/v1.0/v1.0/formattest2.cwl
+++ b/v1.0/v1.0/formattest2.cwl
@@ -6,6 +6,8 @@ class: CommandLineTool
 cwlVersion: v1.0
 doc: "Reverse each line using the `rev` command"
 hints:
+  ResourceRequirement:
+    ramMin: 128
   DockerRequirement:
     dockerPull: "debian:stretch-slim"
 

--- a/v1.0/v1.0/formattest2.cwl
+++ b/v1.0/v1.0/formattest2.cwl
@@ -7,7 +7,7 @@ cwlVersion: v1.0
 doc: "Reverse each line using the `rev` command"
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
   DockerRequirement:
     dockerPull: "debian:stretch-slim"
 

--- a/v1.0/v1.0/formattest3.cwl
+++ b/v1.0/v1.0/formattest3.cwl
@@ -9,7 +9,7 @@ cwlVersion: v1.0
 doc: "Reverse each line using the `rev` command"
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
   DockerRequirement:
     dockerPull: "debian:stretch-slim"
 

--- a/v1.0/v1.0/formattest3.cwl
+++ b/v1.0/v1.0/formattest3.cwl
@@ -8,6 +8,8 @@ class: CommandLineTool
 cwlVersion: v1.0
 doc: "Reverse each line using the `rev` command"
 hints:
+  ResourceRequirement:
+    ramMin: 128
   DockerRequirement:
     dockerPull: "debian:stretch-slim"
 

--- a/v1.0/v1.0/glob-expr-list.cwl
+++ b/v1.0/v1.0/glob-expr-list.cwl
@@ -2,7 +2,7 @@ class: CommandLineTool
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 
 inputs:
   ids:

--- a/v1.0/v1.0/glob-expr-list.cwl
+++ b/v1.0/v1.0/glob-expr-list.cwl
@@ -1,5 +1,8 @@
 class: CommandLineTool
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 
 inputs:
   ids:

--- a/v1.0/v1.0/glob_test.cwl
+++ b/v1.0/v1.0/glob_test.cwl
@@ -3,7 +3,7 @@ cwlVersion: v1.0
 class: CommandLineTool
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 
 inputs: []
 baseCommand: [touch, z, y, x, w, c, b, a]

--- a/v1.0/v1.0/glob_test.cwl
+++ b/v1.0/v1.0/glob_test.cwl
@@ -1,6 +1,9 @@
 #!/usr/bin/env cwl-runner
 cwlVersion: v1.0
 class: CommandLineTool
+hints:
+  ResourceRequirement:
+    ramMin: 128
 
 inputs: []
 baseCommand: [touch, z, y, x, w, c, b, a]

--- a/v1.0/v1.0/import_schema-def_packed.cwl
+++ b/v1.0/v1.0/import_schema-def_packed.cwl
@@ -82,6 +82,10 @@
                 {
                     "dockerPull": "debian:stretch-slim", 
                     "class": "DockerRequirement"
+                },
+                {
+                    "class": "ResourceRequirement",
+                    "ramMin": 128
                 }
             ]
         }

--- a/v1.0/v1.0/imported-hint.cwl
+++ b/v1.0/v1.0/imported-hint.cwl
@@ -3,7 +3,7 @@ cwlVersion: v1.0
 class: CommandLineTool
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 inputs: []
 outputs:
   out: stdout

--- a/v1.0/v1.0/imported-hint.cwl
+++ b/v1.0/v1.0/imported-hint.cwl
@@ -1,6 +1,9 @@
 #!/usr/bin/env cwl-runner
 cwlVersion: v1.0
 class: CommandLineTool
+hints:
+  ResourceRequirement:
+    ramMin: 128
 inputs: []
 outputs:
   out: stdout

--- a/v1.0/v1.0/initialwork-path.cwl
+++ b/v1.0/v1.0/initialwork-path.cwl
@@ -1,5 +1,8 @@
 class: CommandLineTool
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 requirements:
   InitialWorkDirRequirement:
     listing:

--- a/v1.0/v1.0/initialwork-path.cwl
+++ b/v1.0/v1.0/initialwork-path.cwl
@@ -2,7 +2,7 @@ class: CommandLineTool
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 requirements:
   InitialWorkDirRequirement:
     listing:

--- a/v1.0/v1.0/initialworkdirrequirement-docker-out.cwl
+++ b/v1.0/v1.0/initialworkdirrequirement-docker-out.cwl
@@ -1,6 +1,9 @@
 #!/usr/bin/env cwl-runner
 
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 
 requirements:
   - class: DockerRequirement

--- a/v1.0/v1.0/initialworkdirrequirement-docker-out.cwl
+++ b/v1.0/v1.0/initialworkdirrequirement-docker-out.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 
 requirements:
   - class: DockerRequirement

--- a/v1.0/v1.0/inline-js.cwl
+++ b/v1.0/v1.0/inline-js.cwl
@@ -7,7 +7,7 @@ hints:
   - class: DockerRequirement
     dockerPull: python:2-slim
   - class: ResourceRequirement
-    ramMin: 128
+    ramMin: 8
 
 inputs:
   - id: args.py

--- a/v1.0/v1.0/inline-js.cwl
+++ b/v1.0/v1.0/inline-js.cwl
@@ -6,6 +6,8 @@ requirements:
 hints:
   - class: DockerRequirement
     dockerPull: python:2-slim
+  - class: ResourceRequirement
+    ramMin: 128
 
 inputs:
   - id: args.py

--- a/v1.0/v1.0/io-any-1.cwl
+++ b/v1.0/v1.0/io-any-1.cwl
@@ -1,6 +1,9 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 requirements:
  - class: InlineJavascriptRequirement
 

--- a/v1.0/v1.0/io-any-1.cwl
+++ b/v1.0/v1.0/io-any-1.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 requirements:
  - class: InlineJavascriptRequirement
 

--- a/v1.0/v1.0/io-file-or-files.cwl
+++ b/v1.0/v1.0/io-file-or-files.cwl
@@ -1,6 +1,9 @@
 #!/usr/bin/env cwl-runner
 
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 
 requirements:
   - class: InlineJavascriptRequirement

--- a/v1.0/v1.0/io-file-or-files.cwl
+++ b/v1.0/v1.0/io-file-or-files.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 
 requirements:
   - class: InlineJavascriptRequirement

--- a/v1.0/v1.0/iwdr-entry.cwl
+++ b/v1.0/v1.0/iwdr-entry.cwl
@@ -3,6 +3,9 @@
 class: CommandLineTool
 cwlVersion: v1.0
 baseCommand: ["cat", "example.conf"]
+hints:
+  ResourceRequirement:
+    ramMin: 128
 
 requirements:
   InitialWorkDirRequirement:

--- a/v1.0/v1.0/iwdr-entry.cwl
+++ b/v1.0/v1.0/iwdr-entry.cwl
@@ -5,7 +5,7 @@ cwlVersion: v1.0
 baseCommand: ["cat", "example.conf"]
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 
 requirements:
   InitialWorkDirRequirement:

--- a/v1.0/v1.0/js-expr-req-wf.cwl
+++ b/v1.0/v1.0/js-expr-req-wf.cwl
@@ -2,6 +2,9 @@ cwlVersion: v1.0
 $graph:
   - id: tool
     class: CommandLineTool
+    hints:
+      ResourceRequirement:
+        ramMin: 128
     requirements:
       InlineJavascriptRequirement:
         expressionLib:

--- a/v1.0/v1.0/js-expr-req-wf.cwl
+++ b/v1.0/v1.0/js-expr-req-wf.cwl
@@ -4,7 +4,7 @@ $graph:
     class: CommandLineTool
     hints:
       ResourceRequirement:
-        ramMin: 128
+        ramMin: 8
     requirements:
       InlineJavascriptRequirement:
         expressionLib:

--- a/v1.0/v1.0/linkfile.cwl
+++ b/v1.0/v1.0/linkfile.cwl
@@ -1,5 +1,8 @@
 cwlVersion: v1.0
 class: CommandLineTool
+hints:
+  ResourceRequirement:
+    ramMin: 128
 
 requirements:
   InitialWorkDirRequirement:

--- a/v1.0/v1.0/linkfile.cwl
+++ b/v1.0/v1.0/linkfile.cwl
@@ -2,7 +2,7 @@ cwlVersion: v1.0
 class: CommandLineTool
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 
 requirements:
   InitialWorkDirRequirement:

--- a/v1.0/v1.0/metadata.cwl
+++ b/v1.0/v1.0/metadata.cwl
@@ -19,6 +19,8 @@ dct:creator:
 hints:
   DockerRequirement:
     dockerPull: debian:stretch-slim
+  ResourceRequirement:
+    ramMin: 128
 inputs:
   file1:
     type: File

--- a/v1.0/v1.0/metadata.cwl
+++ b/v1.0/v1.0/metadata.cwl
@@ -20,7 +20,7 @@ hints:
   DockerRequirement:
     dockerPull: debian:stretch-slim
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 inputs:
   file1:
     type: File

--- a/v1.0/v1.0/nameroot.cwl
+++ b/v1.0/v1.0/nameroot.cwl
@@ -2,7 +2,7 @@ cwlVersion: v1.0
 class: CommandLineTool
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 inputs:
   file1: File
 outputs:

--- a/v1.0/v1.0/nameroot.cwl
+++ b/v1.0/v1.0/nameroot.cwl
@@ -1,5 +1,8 @@
 cwlVersion: v1.0
 class: CommandLineTool
+hints:
+  ResourceRequirement:
+    ramMin: 128
 inputs:
   file1: File
 outputs:

--- a/v1.0/v1.0/nested-array.cwl
+++ b/v1.0/v1.0/nested-array.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 baseCommand: echo
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 inputs:
   letters:
     type:

--- a/v1.0/v1.0/nested-array.cwl
+++ b/v1.0/v1.0/nested-array.cwl
@@ -1,6 +1,9 @@
 cwlVersion: v1.0
 class: CommandLineTool
 baseCommand: echo
+hints:
+  ResourceRequirement:
+    ramMin: 128
 inputs:
   letters:
     type:

--- a/v1.0/v1.0/no-inputs-tool.cwl
+++ b/v1.0/v1.0/no-inputs-tool.cwl
@@ -5,6 +5,8 @@ doc: "CommandLineTool without inputs."
 hints:
   DockerRequirement:
     dockerPull: debian:stretch-slim
+  ResourceRequirement:
+    ramMin: 128
 inputs: []
 outputs:
   output:

--- a/v1.0/v1.0/no-inputs-tool.cwl
+++ b/v1.0/v1.0/no-inputs-tool.cwl
@@ -6,7 +6,7 @@ hints:
   DockerRequirement:
     dockerPull: debian:stretch-slim
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 inputs: []
 outputs:
   output:

--- a/v1.0/v1.0/no-outputs-tool.cwl
+++ b/v1.0/v1.0/no-outputs-tool.cwl
@@ -6,7 +6,7 @@ hints:
   DockerRequirement:
     dockerPull: debian:stretch-slim
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 inputs:
   file1:
     type: File

--- a/v1.0/v1.0/no-outputs-tool.cwl
+++ b/v1.0/v1.0/no-outputs-tool.cwl
@@ -5,6 +5,8 @@ doc: "CommandLineTool without outputs."
 hints:
   DockerRequirement:
     dockerPull: debian:stretch-slim
+  ResourceRequirement:
+    ramMin: 128
 inputs:
   file1:
     type: File

--- a/v1.0/v1.0/null-defined.cwl
+++ b/v1.0/v1.0/null-defined.cwl
@@ -2,7 +2,7 @@ cwlVersion: v1.0
 class: CommandLineTool
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 requirements:
   InlineJavascriptRequirement: {}
 inputs:

--- a/v1.0/v1.0/null-defined.cwl
+++ b/v1.0/v1.0/null-defined.cwl
@@ -1,5 +1,8 @@
 cwlVersion: v1.0
 class: CommandLineTool
+hints:
+  ResourceRequirement:
+    ramMin: 128
 requirements:
   InlineJavascriptRequirement: {}
 inputs:

--- a/v1.0/v1.0/optional-output.cwl
+++ b/v1.0/v1.0/optional-output.cwl
@@ -6,7 +6,7 @@ hints:
   DockerRequirement:
     dockerPull: debian:stretch-slim
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 inputs:
   file1:
     type: File

--- a/v1.0/v1.0/optional-output.cwl
+++ b/v1.0/v1.0/optional-output.cwl
@@ -5,6 +5,8 @@ doc: "Print the contents of a file to stdout using 'cat' running in a docker con
 hints:
   DockerRequirement:
     dockerPull: debian:stretch-slim
+  ResourceRequirement:
+    ramMin: 128
 inputs:
   file1:
     type: File

--- a/v1.0/v1.0/output-arrays-file-wf.cwl
+++ b/v1.0/v1.0/output-arrays-file-wf.cwl
@@ -39,7 +39,7 @@ steps:
       class: CommandLineTool
       hints:
         ResourceRequirement:
-          ramMin: 128
+          ramMin: 8
 
       inputs:
         i:

--- a/v1.0/v1.0/output-arrays-file-wf.cwl
+++ b/v1.0/v1.0/output-arrays-file-wf.cwl
@@ -37,6 +37,9 @@ steps:
     out: [o]
     run:
       class: CommandLineTool
+      hints:
+        ResourceRequirement:
+          ramMin: 128
 
       inputs:
         i:

--- a/v1.0/v1.0/params.cwl
+++ b/v1.0/v1.0/params.cwl
@@ -1,5 +1,8 @@
 class: CommandLineTool
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 inputs:
   bar:
     type: Any

--- a/v1.0/v1.0/params.cwl
+++ b/v1.0/v1.0/params.cwl
@@ -2,7 +2,7 @@ class: CommandLineTool
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 inputs:
   bar:
     type: Any

--- a/v1.0/v1.0/record-output.cwl
+++ b/v1.0/v1.0/record-output.cwl
@@ -2,7 +2,7 @@ class: CommandLineTool
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 requirements:
   - class: ShellCommandRequirement
 inputs:

--- a/v1.0/v1.0/record-output.cwl
+++ b/v1.0/v1.0/record-output.cwl
@@ -1,5 +1,8 @@
 class: CommandLineTool
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 requirements:
   - class: ShellCommandRequirement
 inputs:

--- a/v1.0/v1.0/recursive-input-directory.cwl
+++ b/v1.0/v1.0/recursive-input-directory.cwl
@@ -2,7 +2,7 @@ cwlVersion: v1.0
 class: CommandLineTool
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 requirements:
   InitialWorkDirRequirement:
     listing:

--- a/v1.0/v1.0/recursive-input-directory.cwl
+++ b/v1.0/v1.0/recursive-input-directory.cwl
@@ -1,5 +1,8 @@
 cwlVersion: v1.0
 class: CommandLineTool
+hints:
+  ResourceRequirement:
+    ramMin: 128
 requirements:
   InitialWorkDirRequirement:
     listing:

--- a/v1.0/v1.0/rename.cwl
+++ b/v1.0/v1.0/rename.cwl
@@ -3,7 +3,7 @@ cwlVersion: v1.0
 baseCommand: "true"
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 requirements:
   InitialWorkDirRequirement:
     listing:

--- a/v1.0/v1.0/rename.cwl
+++ b/v1.0/v1.0/rename.cwl
@@ -1,6 +1,9 @@
 class: CommandLineTool
 cwlVersion: v1.0
 baseCommand: "true"
+hints:
+  ResourceRequirement:
+    ramMin: 128
 requirements:
   InitialWorkDirRequirement:
     listing:

--- a/v1.0/v1.0/revsort-packed.cwl
+++ b/v1.0/v1.0/revsort-packed.cwl
@@ -85,7 +85,13 @@
                 }
             ], 
             "baseCommand": "rev", 
-            "stdout": "output.txt", 
+            "stdout": "output.txt",
+            "hints": [
+                {
+                    "class": "ResourceRequirement",
+                    "ramMin": 128
+                }
+            ],
             "id": "#revtool.cwl"
         }, 
         {
@@ -119,6 +125,12 @@
             ], 
             "baseCommand": "sort", 
             "stdout": "output.txt", 
+            "hints": [
+                {
+                    "class": "ResourceRequirement",
+                    "ramMin": 128
+                }
+            ],
             "id": "#sorttool.cwl"
         }
     ]

--- a/v1.0/v1.0/revtool.cwl
+++ b/v1.0/v1.0/revtool.cwl
@@ -7,7 +7,7 @@ doc: "Reverse each line using the `rev` command"
 
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 
 # The "inputs" array defines the structure of the input object that describes
 # the inputs to the underlying program.  Here, there is one input field

--- a/v1.0/v1.0/revtool.cwl
+++ b/v1.0/v1.0/revtool.cwl
@@ -5,6 +5,10 @@ class: CommandLineTool
 cwlVersion: v1.0
 doc: "Reverse each line using the `rev` command"
 
+hints:
+  ResourceRequirement:
+    ramMin: 128
+
 # The "inputs" array defines the structure of the input object that describes
 # the inputs to the underlying program.  Here, there is one input field
 # defined that will be called "input" and will contain a "File" object.

--- a/v1.0/v1.0/scatter-valueFrom-tool.cwl
+++ b/v1.0/v1.0/scatter-valueFrom-tool.cwl
@@ -1,5 +1,8 @@
 cwlVersion: v1.0
 class: CommandLineTool
+hints:
+  ResourceRequirement:
+    ramMin: 128
 inputs:
   scattered_message:
     type: string

--- a/v1.0/v1.0/scatter-valueFrom-tool.cwl
+++ b/v1.0/v1.0/scatter-valueFrom-tool.cwl
@@ -2,7 +2,7 @@ cwlVersion: v1.0
 class: CommandLineTool
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 inputs:
   scattered_message:
     type: string

--- a/v1.0/v1.0/scatter-valuefrom-inputs-wf1.cwl
+++ b/v1.0/v1.0/scatter-valuefrom-inputs-wf1.cwl
@@ -35,6 +35,9 @@ steps:
     scatter: echo_unused
     run:
       class: CommandLineTool
+      hints:
+        ResourceRequirement:
+          ramMin: 128
       inputs:
         first:
           type: string

--- a/v1.0/v1.0/scatter-valuefrom-inputs-wf1.cwl
+++ b/v1.0/v1.0/scatter-valuefrom-inputs-wf1.cwl
@@ -37,7 +37,7 @@ steps:
       class: CommandLineTool
       hints:
         ResourceRequirement:
-          ramMin: 128
+          ramMin: 8
       inputs:
         first:
           type: string

--- a/v1.0/v1.0/scatter-valuefrom-wf1.cwl
+++ b/v1.0/v1.0/scatter-valuefrom-wf1.cwl
@@ -35,6 +35,9 @@ steps:
     scatter: echo_in
     run:
       class: CommandLineTool
+      hints:
+        ResourceRequirement:
+          ramMin: 128
       inputs:
         first:
           type: string

--- a/v1.0/v1.0/scatter-valuefrom-wf1.cwl
+++ b/v1.0/v1.0/scatter-valuefrom-wf1.cwl
@@ -37,7 +37,7 @@ steps:
       class: CommandLineTool
       hints:
         ResourceRequirement:
-          ramMin: 128
+          ramMin: 8
       inputs:
         first:
           type: string

--- a/v1.0/v1.0/scatter-valuefrom-wf2.cwl
+++ b/v1.0/v1.0/scatter-valuefrom-wf2.cwl
@@ -46,6 +46,9 @@ steps:
     run:
       class: CommandLineTool
       id: step1command
+      hints:
+        ResourceRequirement:
+          ramMin: 128
       inputs:
         first:
           type: string

--- a/v1.0/v1.0/scatter-valuefrom-wf2.cwl
+++ b/v1.0/v1.0/scatter-valuefrom-wf2.cwl
@@ -48,7 +48,7 @@ steps:
       id: step1command
       hints:
         ResourceRequirement:
-          ramMin: 128
+          ramMin: 8
       inputs:
         first:
           type: string

--- a/v1.0/v1.0/scatter-valuefrom-wf3.cwl
+++ b/v1.0/v1.0/scatter-valuefrom-wf3.cwl
@@ -5,6 +5,9 @@ $graph:
 
 - id: echo
   class: CommandLineTool
+  hints:
+    ResourceRequirement:
+      ramMin: 128
   inputs:
     first:
       type: string

--- a/v1.0/v1.0/scatter-valuefrom-wf3.cwl
+++ b/v1.0/v1.0/scatter-valuefrom-wf3.cwl
@@ -7,7 +7,7 @@ $graph:
   class: CommandLineTool
   hints:
     ResourceRequirement:
-      ramMin: 128
+      ramMin: 8
   inputs:
     first:
       type: string

--- a/v1.0/v1.0/scatter-valuefrom-wf4.cwl
+++ b/v1.0/v1.0/scatter-valuefrom-wf4.cwl
@@ -3,6 +3,9 @@ cwlVersion: v1.0
 $graph:
 - id: echo
   class: CommandLineTool
+  hints:
+    ResourceRequirement:
+      ramMin: 128
   inputs:
     first:
       type: string

--- a/v1.0/v1.0/scatter-valuefrom-wf4.cwl
+++ b/v1.0/v1.0/scatter-valuefrom-wf4.cwl
@@ -5,7 +5,7 @@ $graph:
   class: CommandLineTool
   hints:
     ResourceRequirement:
-      ramMin: 128
+      ramMin: 8
   inputs:
     first:
       type: string

--- a/v1.0/v1.0/scatter-valuefrom-wf5.cwl
+++ b/v1.0/v1.0/scatter-valuefrom-wf5.cwl
@@ -35,6 +35,9 @@ steps:
     scatter: echo_in
     run:
       class: CommandLineTool
+      hints:
+        ResourceRequirement:
+          ramMin: 128
       inputs:
         first:
           type: string

--- a/v1.0/v1.0/scatter-valuefrom-wf5.cwl
+++ b/v1.0/v1.0/scatter-valuefrom-wf5.cwl
@@ -37,7 +37,7 @@ steps:
       class: CommandLineTool
       hints:
         ResourceRequirement:
-          ramMin: 128
+          ramMin: 8
       inputs:
         first:
           type: string

--- a/v1.0/v1.0/scatter-wf3.cwl
+++ b/v1.0/v1.0/scatter-wf3.cwl
@@ -5,6 +5,9 @@ $graph:
 
 - id: echo
   class: CommandLineTool
+  hints:
+    ResourceRequirement:
+      ramMin: 128
   inputs:
     echo_in1:
       type: string

--- a/v1.0/v1.0/scatter-wf3.cwl
+++ b/v1.0/v1.0/scatter-wf3.cwl
@@ -7,7 +7,7 @@ $graph:
   class: CommandLineTool
   hints:
     ResourceRequirement:
-      ramMin: 128
+      ramMin: 8
   inputs:
     echo_in1:
       type: string

--- a/v1.0/v1.0/scatter-wf4.cwl
+++ b/v1.0/v1.0/scatter-wf4.cwl
@@ -5,7 +5,7 @@ $graph:
   class: CommandLineTool
   hints:
     ResourceRequirement:
-      ramMin: 128
+      ramMin: 8
   inputs:
     echo_in1:
       type: string

--- a/v1.0/v1.0/scatter-wf4.cwl
+++ b/v1.0/v1.0/scatter-wf4.cwl
@@ -3,6 +3,9 @@ cwlVersion: v1.0
 $graph:
 - id: echo
   class: CommandLineTool
+  hints:
+    ResourceRequirement:
+      ramMin: 128
   inputs:
     echo_in1:
       type: string

--- a/v1.0/v1.0/schemadef-tool.cwl
+++ b/v1.0/v1.0/schemadef-tool.cwl
@@ -1,6 +1,9 @@
 #!/usr/bin/env cwl-runner
 class: CommandLineTool
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 
 requirements:
   - $import: schemadef-type.yml

--- a/v1.0/v1.0/schemadef-tool.cwl
+++ b/v1.0/v1.0/schemadef-tool.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 
 requirements:
   - $import: schemadef-type.yml

--- a/v1.0/v1.0/schemadef-wf.cwl
+++ b/v1.0/v1.0/schemadef-wf.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 class: Workflow
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 
 requirements:
   - $import: schemadef-type.yml

--- a/v1.0/v1.0/schemadef-wf.cwl
+++ b/v1.0/v1.0/schemadef-wf.cwl
@@ -2,6 +2,9 @@
 
 cwlVersion: v1.0
 class: Workflow
+hints:
+  ResourceRequirement:
+    ramMin: 128
 
 requirements:
   - $import: schemadef-type.yml

--- a/v1.0/v1.0/search.cwl
+++ b/v1.0/v1.0/search.cwl
@@ -15,6 +15,8 @@ $graph:
   hints:
     - class: DockerRequirement
       dockerPull: python:2-slim
+    - class: ResourceRequirement
+      ramMin: 128
 
   inputs:
     file:  File
@@ -49,6 +51,8 @@ $graph:
   hints:
     - class: DockerRequirement
       dockerPull: python:2-slim
+    - class: ResourceRequirement
+      ramMin: 128
   inputs:
     file:
       type: File

--- a/v1.0/v1.0/search.cwl
+++ b/v1.0/v1.0/search.cwl
@@ -16,7 +16,7 @@ $graph:
     - class: DockerRequirement
       dockerPull: python:2-slim
     - class: ResourceRequirement
-      ramMin: 128
+      ramMin: 8
 
   inputs:
     file:  File
@@ -52,7 +52,7 @@ $graph:
     - class: DockerRequirement
       dockerPull: python:2-slim
     - class: ResourceRequirement
-      ramMin: 128
+      ramMin: 8
   inputs:
     file:
       type: File

--- a/v1.0/v1.0/shellchar.cwl
+++ b/v1.0/v1.0/shellchar.cwl
@@ -5,6 +5,9 @@ doc: |
   Ensure that arguments containing shell directives are not interpreted and
   that `shellQuote: false` has no effect when ShellCommandRequirement is not in
   effect.
+hints:
+  ResourceRequirement:
+    ramMin: 128
 inputs: []
 outputs:
   stdout_file: stdout

--- a/v1.0/v1.0/shellchar.cwl
+++ b/v1.0/v1.0/shellchar.cwl
@@ -7,7 +7,7 @@ doc: |
   effect.
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 inputs: []
 outputs:
   stdout_file: stdout

--- a/v1.0/v1.0/shellchar2.cwl
+++ b/v1.0/v1.0/shellchar2.cwl
@@ -6,7 +6,7 @@ doc: |
   ShellCommandRequirement is in effect.
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 requirements:
   ShellCommandRequirement: {}
 inputs: []

--- a/v1.0/v1.0/shellchar2.cwl
+++ b/v1.0/v1.0/shellchar2.cwl
@@ -4,6 +4,9 @@ cwlVersion: v1.0
 doc: |
   Ensure that `shellQuote: true` is the default behavior when
   ShellCommandRequirement is in effect.
+hints:
+  ResourceRequirement:
+    ramMin: 128
 requirements:
   ShellCommandRequirement: {}
 inputs: []

--- a/v1.0/v1.0/size-expression-tool.cwl
+++ b/v1.0/v1.0/size-expression-tool.cwl
@@ -1,6 +1,9 @@
 #!/usr/bin/env cwl-runner
 
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 
 requirements:
   - class: InlineJavascriptRequirement

--- a/v1.0/v1.0/size-expression-tool.cwl
+++ b/v1.0/v1.0/size-expression-tool.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 
 requirements:
   - class: InlineJavascriptRequirement

--- a/v1.0/v1.0/sorttool.cwl
+++ b/v1.0/v1.0/sorttool.cwl
@@ -5,7 +5,7 @@ doc: "Sort lines using the `sort` command"
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 
 # This example is similar to the previous one, with an additional input
 # parameter called "reverse".  It is a boolean parameter, which is

--- a/v1.0/v1.0/sorttool.cwl
+++ b/v1.0/v1.0/sorttool.cwl
@@ -3,6 +3,9 @@
 class: CommandLineTool
 doc: "Sort lines using the `sort` command"
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 
 # This example is similar to the previous one, with an additional input
 # parameter called "reverse".  It is a boolean parameter, which is

--- a/v1.0/v1.0/stage-unprovided-file.cwl
+++ b/v1.0/v1.0/stage-unprovided-file.cwl
@@ -4,7 +4,7 @@ hints:
   - class: DockerRequirement
     dockerPull: python:2-slim
   - class: ResourceRequirement
-    ramMin: 128
+    ramMin: 8
 inputs:
   - id: infile
     type: File?

--- a/v1.0/v1.0/stage-unprovided-file.cwl
+++ b/v1.0/v1.0/stage-unprovided-file.cwl
@@ -3,6 +3,8 @@ class: CommandLineTool
 hints:
   - class: DockerRequirement
     dockerPull: python:2-slim
+  - class: ResourceRequirement
+    ramMin: 128
 inputs:
   - id: infile
     type: File?

--- a/v1.0/v1.0/stagefile.cwl
+++ b/v1.0/v1.0/stagefile.cwl
@@ -4,7 +4,7 @@ hints:
   - class: DockerRequirement
     dockerPull: python:2-slim
   - class: ResourceRequirement
-    ramMin: 128
+    ramMin: 8
 requirements:
   InitialWorkDirRequirement:
     listing:

--- a/v1.0/v1.0/stagefile.cwl
+++ b/v1.0/v1.0/stagefile.cwl
@@ -3,6 +3,8 @@ cwlVersion: v1.0
 hints:
   - class: DockerRequirement
     dockerPull: python:2-slim
+  - class: ResourceRequirement
+    ramMin: 128
 requirements:
   InitialWorkDirRequirement:
     listing:

--- a/v1.0/v1.0/stderr-mediumcut.cwl
+++ b/v1.0/v1.0/stderr-mediumcut.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 doc: "Test of capturing stderr output in a docker container."
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 requirements:
   ShellCommandRequirement: {}
 inputs: []

--- a/v1.0/v1.0/stderr-mediumcut.cwl
+++ b/v1.0/v1.0/stderr-mediumcut.cwl
@@ -2,6 +2,9 @@
 class: CommandLineTool
 cwlVersion: v1.0
 doc: "Test of capturing stderr output in a docker container."
+hints:
+  ResourceRequirement:
+    ramMin: 128
 requirements:
   ShellCommandRequirement: {}
 inputs: []

--- a/v1.0/v1.0/stderr-shortcut.cwl
+++ b/v1.0/v1.0/stderr-shortcut.cwl
@@ -2,6 +2,9 @@
 class: CommandLineTool
 cwlVersion: v1.0
 doc: "Test of capturing stderr output."
+hints:
+  ResourceRequirement:
+    ramMin: 128
 requirements:
   ShellCommandRequirement: {}
 inputs: []

--- a/v1.0/v1.0/stderr-shortcut.cwl
+++ b/v1.0/v1.0/stderr-shortcut.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 doc: "Test of capturing stderr output."
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 requirements:
   ShellCommandRequirement: {}
 inputs: []

--- a/v1.0/v1.0/stderr.cwl
+++ b/v1.0/v1.0/stderr.cwl
@@ -2,6 +2,9 @@
 class: CommandLineTool
 cwlVersion: v1.0
 doc: "Test of capturing stderr output."
+hints:
+  ResourceRequirement:
+    ramMin: 128
 requirements:
   ShellCommandRequirement: {}
 inputs: []

--- a/v1.0/v1.0/stderr.cwl
+++ b/v1.0/v1.0/stderr.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 doc: "Test of capturing stderr output."
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 requirements:
   ShellCommandRequirement: {}
 inputs: []

--- a/v1.0/v1.0/template-tool.cwl
+++ b/v1.0/v1.0/template-tool.cwl
@@ -13,6 +13,8 @@ requirements:
 hints:
   DockerRequirement:
     dockerPull: "debian:stretch-slim"
+  ResourceRequirement:
+    ramMin: 128
 inputs:
   - id: file1
     type: File

--- a/v1.0/v1.0/template-tool.cwl
+++ b/v1.0/v1.0/template-tool.cwl
@@ -14,7 +14,7 @@ hints:
   DockerRequirement:
     dockerPull: "debian:stretch-slim"
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 inputs:
   - id: file1
     type: File

--- a/v1.0/v1.0/test-cwl-out.cwl
+++ b/v1.0/v1.0/test-cwl-out.cwl
@@ -3,6 +3,8 @@ cwlVersion: v1.0
 requirements:
   - class: ShellCommandRequirement
 hints:
+  ResourceRequirement:
+    ramMin: 128
   DockerRequirement:
     dockerPull: "debian:stretch-slim"
 

--- a/v1.0/v1.0/test-cwl-out.cwl
+++ b/v1.0/v1.0/test-cwl-out.cwl
@@ -4,7 +4,7 @@ requirements:
   - class: ShellCommandRequirement
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
   DockerRequirement:
     dockerPull: "debian:stretch-slim"
 

--- a/v1.0/v1.0/test-cwl-out2.cwl
+++ b/v1.0/v1.0/test-cwl-out2.cwl
@@ -3,6 +3,8 @@ cwlVersion: v1.0
 requirements:
   - class: ShellCommandRequirement
 hints:
+  ResourceRequirement:
+    ramMin: 128
   DockerRequirement:
     dockerPull: "debian:stretch-slim"
 

--- a/v1.0/v1.0/test-cwl-out2.cwl
+++ b/v1.0/v1.0/test-cwl-out2.cwl
@@ -4,7 +4,7 @@ requirements:
   - class: ShellCommandRequirement
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
   DockerRequirement:
     dockerPull: "debian:stretch-slim"
 

--- a/v1.0/v1.0/tmap-tool.cwl
+++ b/v1.0/v1.0/tmap-tool.cwl
@@ -7,6 +7,10 @@
         {
             "class": "DockerRequirement",
             "dockerPull": "python:2-slim"
+        },
+        {
+            "class": "ResourceRequirement",
+            "ramMin": 128
         }
     ],
     "inputs": [

--- a/v1.0/v1.0/touch.cwl
+++ b/v1.0/v1.0/touch.cwl
@@ -5,6 +5,8 @@ class: CommandLineTool
 hints:
   DockerRequirement:
     dockerPull: debian:stretch-slim
+  ResourceRequirement:
+    ramMin: 128
 
 inputs:
   name:

--- a/v1.0/v1.0/touch.cwl
+++ b/v1.0/v1.0/touch.cwl
@@ -6,7 +6,7 @@ hints:
   DockerRequirement:
     dockerPull: debian:stretch-slim
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 
 inputs:
   name:

--- a/v1.0/v1.0/valueFrom-constant.cwl
+++ b/v1.0/v1.0/valueFrom-constant.cwl
@@ -4,6 +4,8 @@ cwlVersion: v1.0
 hints:
   - class: DockerRequirement
     dockerPull: python:2-slim
+  - class: ResourceRequirement
+    ramMin: 128
 
 inputs:
   - id: array_input

--- a/v1.0/v1.0/valueFrom-constant.cwl
+++ b/v1.0/v1.0/valueFrom-constant.cwl
@@ -5,7 +5,7 @@ hints:
   - class: DockerRequirement
     dockerPull: python:2-slim
   - class: ResourceRequirement
-    ramMin: 128
+    ramMin: 8
 
 inputs:
   - id: array_input

--- a/v1.0/v1.0/vf-concat.cwl
+++ b/v1.0/v1.0/vf-concat.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 requirements:
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
-    ramMin: 128
+    ramMin: 8
 
 baseCommand: echo
 inputs:

--- a/v1.0/v1.0/vf-concat.cwl
+++ b/v1.0/v1.0/vf-concat.cwl
@@ -2,6 +2,8 @@ cwlVersion: v1.0
 class: CommandLineTool
 requirements:
   - class: InlineJavascriptRequirement
+  - class: ResourceRequirement
+    ramMin: 128
 
 baseCommand: echo
 inputs:

--- a/v1.0/v1.0/wc-tool.cwl
+++ b/v1.0/v1.0/wc-tool.cwl
@@ -4,7 +4,7 @@ class: CommandLineTool
 cwlVersion: v1.0
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 
 inputs:
   file1: File

--- a/v1.0/v1.0/wc-tool.cwl
+++ b/v1.0/v1.0/wc-tool.cwl
@@ -2,6 +2,9 @@
 
 class: CommandLineTool
 cwlVersion: v1.0
+hints:
+  ResourceRequirement:
+    ramMin: 128
 
 inputs:
   file1: File

--- a/v1.0/v1.0/wc2-tool.cwl
+++ b/v1.0/v1.0/wc2-tool.cwl
@@ -3,6 +3,9 @@ class: CommandLineTool
 cwlVersion: v1.0
 requirements:
   - class: InlineJavascriptRequirement
+hints:
+  ResourceRequirement:
+    ramMin: 128
 
 inputs:
     - { id: file1, type: File, inputBinding: {} }

--- a/v1.0/v1.0/wc2-tool.cwl
+++ b/v1.0/v1.0/wc2-tool.cwl
@@ -5,7 +5,7 @@ requirements:
   - class: InlineJavascriptRequirement
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 
 inputs:
     - { id: file1, type: File, inputBinding: {} }

--- a/v1.0/v1.0/wc3-tool.cwl
+++ b/v1.0/v1.0/wc3-tool.cwl
@@ -4,6 +4,9 @@ cwlVersion: v1.0
 
 requirements:
   - class: InlineJavascriptRequirement
+hints:
+  ResourceRequirement:
+    ramMin: 128
 
 inputs:
     file1:

--- a/v1.0/v1.0/wc3-tool.cwl
+++ b/v1.0/v1.0/wc3-tool.cwl
@@ -6,7 +6,7 @@ requirements:
   - class: InlineJavascriptRequirement
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 
 inputs:
     file1:

--- a/v1.0/v1.0/wc4-tool.cwl
+++ b/v1.0/v1.0/wc4-tool.cwl
@@ -3,6 +3,9 @@ class: CommandLineTool
 cwlVersion: v1.0
 requirements:
   - class: InlineJavascriptRequirement
+hints:
+  ResourceRequirement:
+    ramMin: 128
 
 inputs:
     file1:

--- a/v1.0/v1.0/wc4-tool.cwl
+++ b/v1.0/v1.0/wc4-tool.cwl
@@ -5,7 +5,7 @@ requirements:
   - class: InlineJavascriptRequirement
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 
 inputs:
     file1:

--- a/v1.0/v1.0/writable-dir-docker.cwl
+++ b/v1.0/v1.0/writable-dir-docker.cwl
@@ -14,7 +14,7 @@ hints:
   - class: DockerRequirement
     dockerPull: alpine
   - class: ResourceRequirement
-    ramMin: 128
+    ramMin: 8
 
 inputs: []
 outputs:

--- a/v1.0/v1.0/writable-dir-docker.cwl
+++ b/v1.0/v1.0/writable-dir-docker.cwl
@@ -13,6 +13,8 @@ requirements:
 hints:
   - class: DockerRequirement
     dockerPull: alpine
+  - class: ResourceRequirement
+    ramMin: 128
 
 inputs: []
 outputs:

--- a/v1.0/v1.0/writable-dir.cwl
+++ b/v1.0/v1.0/writable-dir.cwl
@@ -1,5 +1,8 @@
 cwlVersion: v1.0
 class: CommandLineTool
+hints:
+  ResourceRequirement:
+    ramMin: 128
 requirements:
   InlineJavascriptRequirement: {}
   InitialWorkDirRequirement:

--- a/v1.0/v1.0/writable-dir.cwl
+++ b/v1.0/v1.0/writable-dir.cwl
@@ -2,7 +2,7 @@ cwlVersion: v1.0
 class: CommandLineTool
 hints:
   ResourceRequirement:
-    ramMin: 128
+    ramMin: 8
 requirements:
   InlineJavascriptRequirement: {}
   InitialWorkDirRequirement:


### PR DESCRIPTION
Should lead to faster execution / queuing of the CWL conformance tests for most CWL executors 