### PR TITLE
Test for InitialWorkDirRequirement.listing defaults to read-only

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -2590,3 +2590,11 @@
   doc: Test an anonymous enum inside an array inside a record, SchemaDefRequirement
   tags: [command_line_tool, schema_def]
 
+- doc: Test InitialWorkDirRequirement without writable fails on write
+  id: 198
+  job: v1.0/empty.json
+  should_fail: true
+  tool: v1.0/iwdr_nested_missing_writable.cwl
+  label: initialworkdir_nesteddir_missing_writable
+  tags: [ initial_work_dir, workflow ]
+

--- a/v1.0/v1.0/iwdr_nested_missing_writable.cwl
+++ b/v1.0/v1.0/iwdr_nested_missing_writable.cwl
@@ -26,7 +26,7 @@ steps:
       class: CommandLineTool
       baseCommand: [ touch, deeply/nested/dir/structure/ya ]
       requirements:
-        InitialWorkDirRequirement:
+        InitialWorkDirRequirement: # does not include writable:True
           listing:
             - entry: $(inputs.dir)
       inputs:

--- a/v1.0/v1.0/iwdr_nested_missing_writable.cwl
+++ b/v1.0/v1.0/iwdr_nested_missing_writable.cwl
@@ -1,0 +1,40 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: Workflow
+
+inputs: []
+outputs:
+  ya_empty:
+    type: File
+    outputSource: second/ya
+
+steps:
+  first:
+    run:
+      class: CommandLineTool
+      baseCommand: [ mkdir, -p, deeply/nested/dir/structure ]
+      inputs: []
+      outputs:
+        deep_dir:
+          type: Directory
+          outputBinding: { glob: deeply }
+    in: {}
+    out: [ deep_dir ]
+
+  second:
+    run:
+      class: CommandLineTool
+      baseCommand: [ touch, deeply/nested/dir/structure/ya ]
+      requirements:
+        InitialWorkDirRequirement:
+          listing:
+            - entry: $(inputs.dir)
+      inputs:
+        dir: Directory
+      outputs:
+        ya:
+          type: File
+          outputBinding: { glob: deeply/nested/dir/structure/ya }
+
+    in: { dir: first/deep_dir }
+    out: [ ya ]


### PR DESCRIPTION
Adds a conformance test, declaring that a job should fail if a process tries to write to an InitialWorkDir that has not been marked writable.

For #591 