### PR TITLE
Get JS in test to work in rhino

### DIFF
--- a/v1.0/v1.0/output-arrays-int.cwl
+++ b/v1.0/v1.0/output-arrays-int.cwl
@@ -15,4 +15,4 @@ outputs:
     type: int[]
 
 expression: >
-  ${return {'o': Array.apply(null, {length: inputs.i}).map(Number.call, Number)};}
+  ${return {'o': Array.apply(undefined, {length: inputs.i}).map(Number.call, Number)};}


### PR DESCRIPTION
Couple of conformance tests fail on `rabix` due to a bug in JS evaluation in rhino (https://github.com/mozilla/rhino/issues/433). I guess any Java based implementation using rhino would fail these tests.