### PR TITLE
Use `/usr/bin/sh` rather than `/usr/bin/bash` for `run_test.sh`

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 read -rd "\000" helpmessage <<EOF
 $(basename $0): Run common workflow tool description language conformance tests.


### PR DESCRIPTION
`run_test.sh` is written in bash but it does not use any bash-specific features.
This request is to change its shebang from `bash` to `sh` to reduce the dependencies.

I confirmed `sh -n` and `checkbaskisms` succeeds without any errors.

Note: This kind of reduction is important when we want to run the conformance test on tiny Linux distributions such as Alpine Linux.
