### PR TITLE
Set root workflow for conformance #135

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -1892,7 +1892,7 @@
       basename: a.bam
       class: File
       size: 0
-  tool: v1.0/import_schema-def_packed.cwl
+  tool: "v1.0/import_schema-def_packed.cwl#main"
   label: packed_import_schema
   id: 135
   doc: SchemaDefRequirement with $import, and packed


### PR DESCRIPTION
The packed CWL in this test has two possible entry points, `main` and `touch.cwl`.

Other test cases with multiple entry points specify a root workflow, so I think I'm doing something reasonable here by making this case consistent with the others.