### PR TITLE
Add `stdout` and `stderr` as symbols for CWLType

### DIFF
--- a/v1.0/Process.yml
+++ b/v1.0/Process.yml
@@ -44,6 +44,8 @@ $graph:
   symbols:
     - cwl:File
     - cwl:Directory
+    - cwl:stdout
+    - cwl:stderr
   doc:
     - "Extends primitive types with the concept of a file and directory as a builtin type."
     - "File: A File object"


### PR DESCRIPTION
`stdout` and `stderr` were missing as symbols for CWLType