### PR TITLE
Fix tag for StepInputExpressionRequirement

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -1557,7 +1557,7 @@
   label: nameroot_nameext_generated
   id: 111
   doc: Test that nameroot and nameext are generated from basename at execution time by the runner
-  tags: [ step_input_expression, workflow ]
+  tags: [ step_input, workflow ]
 
 - job: v1.0/wc-job.json
   output: {}


### PR DESCRIPTION
Most tests with `StepInputExpressionRequirement` uses `step_input` tag but the test 111 uses `step_input_expression`.
This request fixes it.