### PR TITLE
Tests: bugfix: File class objects should use `location`, not `path`.

### DIFF
--- a/v1.0/v1.0/dynresreq-workflow-inputdefault.cwl
+++ b/v1.0/v1.0/dynresreq-workflow-inputdefault.cwl
@@ -7,7 +7,7 @@ inputs:
     type: File
     default:
       class: File
-      path: special_file
+      location: special_file
 
 outputs:
   cores:

--- a/v1.0/v1.0/io-file-default-wf.cwl
+++ b/v1.0/v1.0/io-file-default-wf.cwl
@@ -6,7 +6,7 @@ inputs:
     type: File
     default:
       class: File
-      path: whale.txt
+      location: whale.txt
 
 outputs:
   o:


### PR DESCRIPTION
This fixes test 150, 151 and 184 on Arvados.