### PR TITLE
Any does not include nulls

### DIFF
--- a/v1.0/v1.0/null-expression3-tool.cwl
+++ b/v1.0/v1.0/null-expression3-tool.cwl
@@ -7,6 +7,6 @@ cwlVersion: v1.0
 inputs: []
 
 outputs:
-  output: Any
+  output: Any?
 
 expression: "$({'output': null })"


### PR DESCRIPTION
There is a bug in cwltool; it allows an `ExpressionTool` to return `null` for an `Any`, but rejects the same from `cwl.output.json` output reporting from a `CommandLineTool`.

@tetron How shall we handle this? Fix all occurrences of `Any` that should be `Any?` in the v1.0 conformances tests and release CWL v1.0.3 ?