### PR TITLE
Fix typo

### DIFF
--- a/v1.0/CommandLineTool.yml
+++ b/v1.0/CommandLineTool.yml
@@ -71,7 +71,7 @@ $graph:
         * Syntax simplifcations: denoted by the `map<>` syntax. Example: inputs
           contains a list of items, each with an id. Now one can specify
           a mapping of that identifier to the corresponding
-          `CommandInputParamater`.
+          `CommandInputParameter`.
           ```
           inputs:
            - id: one


### PR DESCRIPTION
 `CommandInputParam"a"ter` -> `CommandInputParam"e"ter`