### PR TITLE
Move `label` to `id`

### DIFF
--- a/v1.0/conformance_test_v1.0.yaml
+++ b/v1.0/conformance_test_v1.0.yaml
@@ -5,8 +5,7 @@
       chr20.fa,
       example_human_Illumina.pe_1.fastq,
       example_human_Illumina.pe_2.fastq]
-  label: cl_basic_generation
-  id: 1
+  id: cl_basic_generation
   doc: General test of command line generation
   tags: [ required, command_line_tool ]
 
@@ -17,8 +16,7 @@
       "-YYY", example_human_Illumina.pe_2.fastq]
   job: v1.0/bwa-mem-job.json
   tool: v1.0/binding-test.cwl
-  label: nested_prefixes_arrays
-  id: 2
+  id: nested_prefixes_arrays
   doc: Test nested prefixes with arrays
   tags: [ required, command_line_tool ]
 
@@ -28,8 +26,7 @@
     '16', map2, --max-seed-hits, '-1', --max-seq-length, '20', --min-seq-length, '10']
   job: v1.0/tmap-job.json
   tool: v1.0/tmap-tool.cwl
-  label: nested_cl_bindings
-  id: 3
+  id: nested_cl_bindings
   doc: Test nested command line bindings
   tags: [ schema_def, command_line_tool ]
 
@@ -37,8 +34,7 @@
     args: [cat, hello.txt]
   job: v1.0/cat-job.json
   tool: v1.0/cat1-testcli.cwl
-  label: cl_optional_inputs_missing
-  id: 4
+  id: cl_optional_inputs_missing
   doc: Test command line with optional input (missing)
   tags: [ required, command_line_tool ]
 
@@ -46,8 +42,7 @@
     args: [cat, -n, hello.txt]
   job: v1.0/cat-n-job.json
   tool: v1.0/cat1-testcli.cwl
-  label: cl_optional_bindings_provided
-  id: 5
+  id: cl_optional_bindings_provided
   doc: Test command line with optional input (provided)
   tags: [ required, command_line_tool ]
 
@@ -60,8 +55,7 @@
     }
   job: v1.0/cat-job.json
   tool: v1.0/template-tool.cwl
-  label: initworkdir_expreng_requirements
-  id: 6
+  id: initworkdir_expreng_requirements
   doc: Test InitialWorkDirRequirement ExpressionEngineRequirement.engineConfig feature
   tags: [ initial_work_dir, inline_javascript, command_line_tool ]
 
@@ -73,8 +67,7 @@
       location: output.txt
       size: 13
   tool: v1.0/cat3-tool-docker.cwl
-  label: stdout_redirect_docker
-  id: 7
+  id: stdout_redirect_docker
   doc: Test command execution in Docker with stdout redirection
   tags: [ docker, command_line_tool ]
 
@@ -86,8 +79,7 @@
       checksum: sha1$47a013e660d408619d894b20806b1d5086aab03b
       location: Any
       size: 13
-  label: stdout_redirect_shortcut_docker
-  id: 8
+  id: stdout_redirect_shortcut_docker
   doc: Test command execution in Docker with shortcut stdout redirection
   tags: [ docker, command_line_tool ]
 
@@ -99,15 +91,13 @@
       location: cat-out
       size: 13
   tool: v1.0/cat3-tool-mediumcut.cwl
-  label: stdout_redirect_mediumcut_docker
-  id: 9
+  id: stdout_redirect_mediumcut_docker
   doc: Test command execution in Docker with mediumcut stdout redirection
   tags: [ docker, command_line_tool ]
 
 - job: v1.0/empty.json
   tool: v1.0/stderr.cwl
-  label: stderr_redirect
-  id: 10
+  id: stderr_redirect
   doc: Test command line with stderr redirection
   output:
     output_file:
@@ -119,8 +109,7 @@
 
 - job: v1.0/empty.json
   tool: v1.0/stderr-shortcut.cwl
-  label: stderr_redirect_shortcut
-  id: 11
+  id: stderr_redirect_shortcut
   doc: Test command line with stderr redirection, brief syntax
   output:
     output_file:
@@ -138,8 +127,7 @@
       location: std.err
   job: v1.0/empty.json
   tool: v1.0/stderr-mediumcut.cwl
-  label: stderr_redirect_mediumcut
-  id: 12
+  id: stderr_redirect_mediumcut
   doc: Test command line with stderr redirection, named brief syntax
   tags: [ shell_command, command_line_tool ]
 
@@ -151,8 +139,7 @@
       location: output.txt
       size: 13
   tool: v1.0/cat4-tool.cwl
-  label: stdinout_redirect_docker
-  id: 13
+  id: stdinout_redirect_docker
   doc: Test command execution in Docker with stdin and stdout redirection
   tags: [ required, command_line_tool ]
 
@@ -160,8 +147,7 @@
   tool: v1.0/null-expression1-tool.cwl
   output:
     output: 1
-  label: expression_any
-  id: 14
+  id: expression_any
   doc: Test default usage of Any in expressions.
   tags: [ inline_javascript, expression_tool ]
 
@@ -169,8 +155,7 @@
   tool: v1.0/null-expression1-tool.cwl
   output:
     output: 1
-  label: expression_any_null
-  id: 15
+  id: expression_any_null
   doc: Test explicitly passing null to Any type inputs with default values.
   tags: [ inline_javascript, expression_tool ]
 
@@ -178,24 +163,21 @@
   tool: v1.0/null-expression1-tool.cwl
   output:
     output: 2
-  label: expression_any_string
-  id: 16
+  id: expression_any_string
   doc: Testing the string 'null' does not trip up an Any with a default value.
   tags: [ inline_javascript, expression_tool ]
 
 - job: v1.0/empty.json
   tool: v1.0/null-expression2-tool.cwl
   should_fail: true
-  label: expression_any_nodefaultany
-  id: 17
+  id: expression_any_nodefaultany
   doc: Test Any without defaults cannot be unspecified.
   tags: [ inline_javascript, expression_tool ]
 
 - job: v1.0/null-expression1-job.json
   tool: v1.0/null-expression2-tool.cwl
   should_fail: true
-  label: expression_any_null_nodefaultany
-  id: 18
+  id: expression_any_null_nodefaultany
   doc: Test explicitly passing null to Any type without a default value.
   tags: [ inline_javascript, expression_tool ]
 
@@ -203,8 +185,7 @@
   tool: v1.0/null-expression2-tool.cwl
   output:
     output: 2
-  label: expression_any_nullstring_nodefaultany
-  id: 19
+  id: expression_any_nullstring_nodefaultany
   doc: Testing the string 'null' does not trip up an Any without a default value.
   tags: [ inline_javascript, expression_tool ]
 
@@ -214,8 +195,7 @@
     output1: ["hello", "world"]
     output2: ["foo", "bar"]
     output3: hello
-  label: any_outputSource_compatibility
-  id: 20
+  id: any_outputSource_compatibility
   doc: Testing Any type compatibility in outputSource
   tags: [ required, workflow ]
 
@@ -227,40 +207,35 @@
       location: output
       size: 13
   tool: v1.0/cat-tool.cwl
-  label: stdinout_redirect
-  id: 21
+  id: stdinout_redirect
   doc: Test command execution in with stdin and stdout redirection
   tags: [ required, command_line_tool ]
 
 - job: v1.0/parseInt-job.json
   output: {output: 42}
   tool: v1.0/parseInt-tool.cwl
-  label: expression_parseint
-  id: 22
+  id: expression_parseint
   doc: Test ExpressionTool with Javascript engine
   tags: [ inline_javascript, expression_tool ]
 
 - job: v1.0/wc-job.json
   output: {output: 16}
   tool: v1.0/wc2-tool.cwl
-  label: expression_outputEval
-  id: 23
+  id: expression_outputEval
   doc: Test outputEval to transform output
   tags: [ inline_javascript, command_line_tool ]
 
 - job: v1.0/wc-job.json
   output: {count_output: 16}
   tool: v1.0/count-lines1-wf.cwl
-  label: wf_wc_parseInt
-  id: 24
+  id: wf_wc_parseInt
   doc: Test two step workflow with imported tools
   tags: [ inline_javascript, workflow ]
 
 - job: v1.0/wc-job.json
   output: {count_output: 16}
   tool: v1.0/count-lines2-wf.cwl
-  label: wf_wc_expressiontool
-  id: 25
+  id: wf_wc_expressiontool
   doc: Test two step workflow with inline tools
   tags: [ inline_javascript, workflow ]
 
@@ -268,8 +243,7 @@
   output:
     count_output: [16, 1]
   tool: v1.0/count-lines3-wf.cwl
-  label: wf_wc_scatter
-  id: 26
+  id: wf_wc_scatter
   doc: Test single step workflow with Scatter step
   tags: [ scatter, inline_javascript, workflow ]
 
@@ -277,8 +251,7 @@
   output:
     count_output: [16, 1]
   tool: v1.0/count-lines4-wf.cwl
-  label: wf_wc_scatter_multiple_merge
-  id: 27
+  id: wf_wc_scatter_multiple_merge
   doc: >-
     Test single step workflow with Scatter step and two data links connected to
     same input, default merge behavior
@@ -288,8 +261,7 @@
   output:
     count_output: [32, 2]
   tool: v1.0/count-lines6-wf.cwl
-  label: wf_wc_scatter_multiple_nested
-  id: 28
+  id: wf_wc_scatter_multiple_nested
   doc: >-
     Test single step workflow with Scatter step and two data links connected to
     same input, nested merge behavior
@@ -299,8 +271,7 @@
   output:
     count_output: 34
   tool: v1.0/count-lines7-wf.cwl
-  label: wf_wc_scatter_multiple_flattened
-  id: 29
+  id: wf_wc_scatter_multiple_flattened
   doc: >-
     Test single step workflow with Scatter step and two data links connected to
     same input, flattened merge behavior
@@ -310,8 +281,7 @@
   output:
     count_output: 32
   tool: v1.0/count-lines13-wf.cwl
-  label: wf_wc_nomultiple
-  id: 30
+  id: wf_wc_nomultiple
   doc: >-
     Test that no MultipleInputFeatureRequirement is necessary when
     workflow step source is a single-item list
@@ -320,24 +290,21 @@
 - job: v1.0/empty.json
   output: {count_output: 1}
   tool: v1.0/count-lines5-wf.cwl
-  label: wf_input_default_missing
-  id: 31
+  id: wf_input_default_missing
   doc: Test workflow with default value for input parameter (missing)
   tags: [ inline_javascript, workflow ]
 
 - job: v1.0/wc-job.json
   output: {count_output: 16}
   tool: v1.0/count-lines5-wf.cwl
-  label: wf_input_default_provided
-  id: 32
+  id: wf_input_default_provided
   doc: Test workflow with default value for input parameter (provided)
   tags: [ inline_javascript, workflow ]
 
 - job: v1.0/empty.json
   output: {default_output: workflow_default}
   tool: v1.0/echo-wf-default.cwl
-  label: wf_default_tool_default
-  id: 33
+  id: wf_default_tool_default
   doc: Test that workflow defaults override tool defaults
   tags: [ required, workflow ]
 
@@ -349,8 +316,7 @@
       location: out
       size: 15
   tool: v1.0/env-tool1.cwl
-  label: envvar_req
-  id: 34
+  id: envvar_req
   doc: Test EnvVarRequirement
   tags: [ env_var, command_line_tool ]
 
@@ -358,8 +324,7 @@
   output:
     out: ["foo one", "foo two", "foo three", "foo four"]
   tool: v1.0/scatter-wf1.cwl
-  label: wf_scatter_single_param
-  id: 35
+  id: wf_scatter_single_param
   doc: Test workflow scatter with single scatter parameter
   tags: [ scatter, workflow ]
 
@@ -367,8 +332,7 @@
   output:
     out: [["foo one three", "foo one four"], ["foo two three", "foo two four"]]
   tool: v1.0/scatter-wf2.cwl
-  label: wf_scatter_two_nested_crossproduct
-  id: 36
+  id: wf_scatter_two_nested_crossproduct
   doc: Test workflow scatter with two scatter parameters and nested_crossproduct join method
   tags: [ scatter, workflow ]
 
@@ -376,8 +340,7 @@
   output:
     out: ["foo one three", "foo one four", "foo two three", "foo two four"]
   tool: "v1.0/scatter-wf3.cwl#main"
-  label: wf_scatter_two_flat_crossproduct
-  id: 37
+  id: wf_scatter_two_flat_crossproduct
   doc: Test workflow scatter with two scatter parameters and flat_crossproduct join method
   tags: [ scatter, workflow ]
 
@@ -385,8 +348,7 @@
   output:
     out: ["foo one three", "foo two four"]
   tool: "v1.0/scatter-wf4.cwl#main"
-  label: wf_scatter_two_dotproduct
-  id: 38
+  id: wf_scatter_two_dotproduct
   doc: Test workflow scatter with two scatter parameters and dotproduct join method
   tags: [ scatter, workflow ]
 
@@ -394,8 +356,7 @@
   output:
     out: []
   tool: v1.0/scatter-wf1.cwl
-  label: wf_scatter_emptylist
-  id: 39
+  id: wf_scatter_emptylist
   doc: Test workflow scatter with single empty list parameter
   tags: [ scatter, workflow ]
 
@@ -403,8 +364,7 @@
   output:
     out: [[], []]
   tool: v1.0/scatter-wf2.cwl
-  label: wf_scatter_nested_crossproduct_secondempty
-  id: 40
+  id: wf_scatter_nested_crossproduct_secondempty
   doc: Test workflow scatter with two scatter parameters and nested_crossproduct join method with second list empty
   tags: [ scatter, workflow ]
 
@@ -412,8 +372,7 @@
   output:
     out: []
   tool: "v1.0/scatter-wf3.cwl#main"
-  label: wf_scatter_nested_crossproduct_firstempty
-  id: 41
+  id: wf_scatter_nested_crossproduct_firstempty
   doc: Test workflow scatter with two scatter parameters and nested_crossproduct join method with first list empty
   tags: [ scatter, workflow ]
 
@@ -421,8 +380,7 @@
   output:
     out: []
   tool: "v1.0/scatter-wf3.cwl#main"
-  label: wf_scatter_flat_crossproduct_oneempty
-  id: 42
+  id: wf_scatter_flat_crossproduct_oneempty
   doc: Test workflow scatter with two scatter parameters, one of which is empty and flat_crossproduct join method
   tags: [ scatter, workflow ]
 
@@ -430,8 +388,7 @@
   output:
     out: []
   tool: "v1.0/scatter-wf4.cwl#main"
-  label: wf_scatter_dotproduct_twoempty
-  id: 43
+  id: wf_scatter_dotproduct_twoempty
   doc: Test workflow scatter with two empty scatter parameters and dotproduct join method
   tags: [ scatter, workflow ]
 
@@ -439,16 +396,14 @@
   job: v1.0/env-job.json
   output:
     {"out": "hello test env\n"}
-  label: any_input_param
-  id: 44
+  id: any_input_param
   doc: Test Any type input parameter
   tags: [ required, command_line_tool ]
 
 - job: v1.0/wc-job.json
   output: {count_output: 16}
   tool: v1.0/count-lines8-wf.cwl
-  label: nested_workflow
-  id: 45
+  id: nested_workflow
   doc: Test nested workflow
   tags: [ subworkflow, workflow, inline_javascript ]
 
@@ -460,8 +415,7 @@
       location: out
       size: 15
   tool: v1.0/env-wf1.cwl
-  label: requirement_priority
-  id: 46
+  id: requirement_priority
   doc: Test requirement priority
   tags: [ env_var, workflow ]
 
@@ -473,8 +427,7 @@
       location: out
       size: 9
   tool: v1.0/env-wf2.cwl
-  label: requirement_override_hints
-  id: 47
+  id: requirement_override_hints
   doc: Test requirements override hints
   tags: [ env_var, workflow ]
 
@@ -486,40 +439,35 @@
       location: out
       size: 9
   tool: v1.0/env-wf3.cwl
-  label: requirement_workflow_steps
-  id: 48
+  id: requirement_workflow_steps
   doc: Test requirements on workflow steps
   tags: [ env_var, workflow ]
 
 - job: v1.0/empty.json
   output: {count_output: 16}
   tool: v1.0/count-lines9-wf.cwl
-  label: step_input_default_value
-  id: 49
+  id: step_input_default_value
   doc: Test default value on step input parameter
   tags: [ inline_javascript, workflow ]
 
 - job: v1.0/empty.json
   output: {count_output: 16}
   tool: v1.0/count-lines11-wf.cwl
-  label: step_input_default_value_nosource
-  id: 50
+  id: step_input_default_value_nosource
   doc: Test use default value on step input parameter with empty source
   tags: [ inline_javascript, workflow ]
 
 - job: v1.0/file1-null.json
   output: {count_output: 16}
   tool: v1.0/count-lines11-wf.cwl
-  label: step_input_default_value_nullsource
-  id: 51
+  id: step_input_default_value_nullsource
   doc: Test use default value on step input parameter with null source
   tags: [ inline_javascript, workflow ]
 
 - job: v1.0/cat-job.json
   output: {count_output: 1}
   tool: v1.0/count-lines11-wf.cwl
-  label: step_input_default_value_overriden
-  id: 52
+  id: step_input_default_value_overriden
   doc: Test default value on step input parameter overridden by provided source
   tags: [ inline_javascript, workflow ]
 
@@ -531,8 +479,7 @@
       location: output.txt
       size: 1111
   tool: v1.0/revsort.cwl
-  label: wf_simple
-  id: 53
+  id: wf_simple
   doc: Test simple workflow
   tags: [ required, workflow ]
 
@@ -544,8 +491,7 @@
       location: output.txt
       size: 13
   tool: v1.0/cat5-tool.cwl
-  label: hints_unknown_ignored
-  id: 54
+  id: hints_unknown_ignored
   doc: Test unknown hints are ignored.
   tags: [ required, command_line_tool ]
 
@@ -624,8 +570,7 @@
         "size": 1111
     }
   tool: "v1.0/search.cwl#main"
-  label: initial_workdir_secondary_files_expr
-  id: 55
+  id: initial_workdir_secondary_files_expr
   doc: >-
     Test InitialWorkDirRequirement linking input files and capturing secondaryFiles
     on input and output. Also tests the use of a variety of parameter references
@@ -640,8 +585,7 @@
       location: fish.txt
       size: 1111
   tool: v1.0/rename.cwl
-  label: rename
-  id: 56
+  id: rename
   doc: >-
     Test InitialWorkDirRequirement with expression in filename.
   tags: [ initial_work_dir, command_line_tool ]
@@ -654,8 +598,7 @@
         location: example.conf
         size: 16
   tool: v1.0/iwdr-entry.cwl
-  label: initial_workdir_trailingnl
-  id: 57
+  id: initial_workdir_trailingnl
   doc: Test if trailing newline is present in file entry in InitialWorkDir
   tags: [ initial_work_dir, command_line_tool ]
 
@@ -663,8 +606,7 @@
   output:
     output: 16
   tool: v1.0/wc4-tool.cwl
-  label: inline_expressions
-  id: 58
+  id: inline_expressions
   doc: >-
     Test inline expressions
   tags: [ inline_javascript, command_line_tool ]
@@ -677,8 +619,7 @@
         class: File
         checksum: "sha1$f12e6cfe70f3253f70b0dbde17c692e7fb0f1e5e"
   tool: v1.0/schemadef-tool.cwl
-  label: schemadef_req_tool_param
-  id: 59
+  id: schemadef_req_tool_param
   doc: >-
     Test SchemaDefRequirement definition used in tool parameter
   tags: [ schema_def, command_line_tool ]
@@ -691,8 +632,7 @@
         class: File
         checksum: "sha1$f12e6cfe70f3253f70b0dbde17c692e7fb0f1e5e"
   tool: v1.0/schemadef-wf.cwl
-  label: schemadef_req_wf_param
-  id: 60
+  id: schemadef_req_wf_param
   doc: >-
     Test SchemaDefRequirement definition used in workflow parameter
   tags: [ schema_def, workflow ]
@@ -771,8 +711,7 @@
     "t28": 3
     }
   tool: v1.0/params.cwl
-  label: param_evaluation_noexpr
-  id: 61
+  id: param_evaluation_noexpr
   doc: >-
     Test parameter evaluation, no support for JS expressions
   tags: [ required, command_line_tool ]
@@ -851,8 +790,7 @@
     "t28": 3
     }
   tool: v1.0/params2.cwl
-  label: param_evaluation_expr
-  id: 62
+  id: param_evaluation_expr
   doc: >-
     Test parameter evaluation, with support for JS expressions
   tags: [ inline_javascript, command_line_tool ]
@@ -860,8 +798,7 @@
 - output: {}
   job: v1.0/cat-job.json
   tool: v1.0/metadata.cwl
-  label: metadata
-  id: 63
+  id: metadata
   doc: Test metadata
   tags: [ required, command_line_tool ]
 
@@ -874,8 +811,7 @@
         "class": "File"
         "checksum": "sha1$97fe1b50b4582cebc7d853796ebd62e3e163aa3f"
   tool: v1.0/formattest.cwl
-  label: format_checking
-  id: 64
+  id: format_checking
   doc: >-
     Test simple format checking.
   tags: [ required, command_line_tool ]
@@ -889,8 +825,7 @@
         "class": "File"
         "checksum": "sha1$971d88faeda85a796752ecf752b7e2e34f1337ce"
   tool: v1.0/formattest2.cwl
-  label: format_checking_subclass
-  id: 65
+  id: format_checking_subclass
   doc: >-
     Test format checking against ontology using subclassOf.
   tags: [ required, command_line_tool ]
@@ -904,8 +839,7 @@
         "class": "File"
         "checksum": "sha1$971d88faeda85a796752ecf752b7e2e34f1337ce"
   tool: v1.0/formattest3.cwl
-  label: format_checking_equivalentclass
-  id: 66
+  id: format_checking_equivalentclass
   doc: >-
     Test format checking against ontology using equivalentClass.
   tags: [ required, command_line_tool ]
@@ -919,8 +853,7 @@
         size: 13
         class: "File"
         checksum: "sha1$47a013e660d408619d894b20806b1d5086aab03b"
-  label: output_secondaryfile_optional
-  id: 67
+  id: output_secondaryfile_optional
   doc: >-
     Test optional output file and optional secondaryFile on output.
   tags: [ docker, command_line_tool ]
@@ -930,8 +863,7 @@
   output:
     out: "\n"
   tool: v1.0/vf-concat.cwl
-  label: valuefrom_ignored_null
-  id: 68
+  id: valuefrom_ignored_null
   doc: Test that valueFrom is ignored when the parameter is null
   tags: [ inline_javascript, command_line_tool ]
 
@@ -939,32 +871,28 @@
   output:
     out: "a string\n"
   tool: v1.0/vf-concat.cwl
-  label: valuefrom_secondexpr_ignored
-  id: 69
+  id: valuefrom_secondexpr_ignored
   doc: Test that second expression in concatenated valueFrom is not ignored
   tags: [ inline_javascript, command_line_tool ]
 
 - job: v1.0/step-valuefrom-wf.json
   output: {count_output: 16}
   tool: v1.0/step-valuefrom-wf.cwl
-  label: valuefrom_wf_step
-  id: 70
+  id: valuefrom_wf_step
   doc: Test valueFrom on workflow step.
   tags: [ step_input, inline_javascript, workflow ]
 
 - job: v1.0/step-valuefrom-job.json
   output: {val: "3\n"}
   tool: v1.0/step-valuefrom2-wf.cwl
-  label: valuefrom_wf_step_multiple
-  id: 71
+  id: valuefrom_wf_step_multiple
   doc: Test valueFrom on workflow step with multiple sources
   tags: [ step_input, inline_javascript, multiple_input, workflow ]
 
 - job: v1.0/step-valuefrom-job.json
   output: {val: "3\n"}
   tool: v1.0/step-valuefrom3-wf.cwl
-  label: valuefrom_wf_step_other
-  id: 72
+  id: valuefrom_wf_step_other
   doc: Test valueFrom on workflow step referencing other inputs
   tags: [ step_input, inline_javascript, workflow ]
 
@@ -985,8 +913,7 @@
         }
     }
   tool: v1.0/record-output.cwl
-  label: record_output_binding
-  id: 73
+  id: record_output_binding
   doc: Test record type output binding.
   tags: [ shell_command, command_line_tool ]
 
@@ -1000,8 +927,7 @@
     }
   }
   tool: v1.0/test-cwl-out.cwl
-  label: docker_json_output_path
-  id: 74
+  id: docker_json_output_path
   doc: >-
     Test support for reading cwl.output.json when running in a Docker container
     and just 'path' is provided.
@@ -1017,8 +943,7 @@
     }
   }
   tool: v1.0/test-cwl-out2.cwl
-  label: docker_json_output_location
-  id: 75
+  id: docker_json_output_location
   doc: >-
     Test support for reading cwl.output.json when running in a Docker container
     and just 'location' is provided.
@@ -1045,8 +970,7 @@
         "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709"
     }]
   tool: v1.0/glob-expr-list.cwl
-  label: multiple_glob_expr_list
-  id: 76
+  id: multiple_glob_expr_list
   doc: Test support for returning multiple glob patterns from expression
   tags: [ required, command_line_tool ]
 
@@ -1054,8 +978,7 @@
   output:
     out: ["foo one one", "foo one two", "foo one three", "foo one four"]
   tool: v1.0/scatter-valuefrom-wf1.cwl
-  label: wf_scatter_oneparam_valuefrom
-  id: 77
+  id: wf_scatter_oneparam_valuefrom
   doc: Test workflow scatter with single scatter parameter and two valueFrom on step input (first and current el)
   tags: [ scatter, step_input, workflow ]
 
@@ -1063,8 +986,7 @@
   output:
     out: [["foo one one three", "foo one one four"], ["foo one two three", "foo one two four"]]
   tool: v1.0/scatter-valuefrom-wf2.cwl
-  label: wf_scatter_twoparam_nested_crossproduct_valuefrom
-  id: 78
+  id: wf_scatter_twoparam_nested_crossproduct_valuefrom
   doc: Test workflow scatter with two scatter parameters and nested_crossproduct join method and valueFrom on step input
   tags: [ scatter, step_input, workflow ]
 
@@ -1072,8 +994,7 @@
   output:
     out: ["foo one one three", "foo one one four", "foo one two three", "foo one two four"]
   tool: "v1.0/scatter-valuefrom-wf3.cwl#main"
-  label: wf_scatter_twoparam_flat_crossproduct_valuefrom
-  id: 79
+  id: wf_scatter_twoparam_flat_crossproduct_valuefrom
   doc: Test workflow scatter with two scatter parameters and flat_crossproduct join method and valueFrom on step input
   tags: [ scatter, step_input, workflow ]
 
@@ -1081,8 +1002,7 @@
   output:
     out: ["foo one one three", "foo one two four"]
   tool: "v1.0/scatter-valuefrom-wf4.cwl#main"
-  label: wf_scatter_twoparam_dotproduct_valuefrom
-  id: 80
+  id: wf_scatter_twoparam_dotproduct_valuefrom
   doc: Test workflow scatter with two scatter parameters and dotproduct join method and valueFrom on step input
   tags: [ scatter, step_input, workflow ]
 
@@ -1090,15 +1010,13 @@
   output:
     out: ["foo one one", "foo two two", "foo three three", "foo four four"]
   tool: v1.0/scatter-valuefrom-wf5.cwl
-  label: wf_scatter_oneparam_valuefrom_twice_current_el
-  id: 81
+  id: wf_scatter_oneparam_valuefrom_twice_current_el
   doc: Test workflow scatter with single scatter parameter and two valueFrom on step input (current el twice)
   tags: [ scatter, step_input, workflow ]
 
 - job: v1.0/scatter-valuefrom-job3.json
   tool: v1.0/scatter-valuefrom-wf6.cwl
-  label: wf_scatter_oneparam_valueFrom
-  id: 82
+  id: wf_scatter_oneparam_valueFrom
   doc: Test valueFrom eval on scattered input parameter
   output:
     out_message: [
@@ -1127,8 +1045,7 @@
     }
   }
   tool: "v1.0/conflict-wf.cwl#collision"
-  label: wf_two_inputfiles_namecollision
-  id: 83
+  id: wf_two_inputfiles_namecollision
   doc: Test workflow two input files with same name.
   tags: [ required, workflow ]
 
@@ -1141,8 +1058,7 @@
         "class": "File"
     }
   tool: v1.0/dir.cwl
-  label: directory_input_param_ref
-  id: 84
+  id: directory_input_param_ref
   doc: Test directory input with parameter reference
   tags: [ shell_command, command_line_tool ]
 
@@ -1155,8 +1071,7 @@
         "class": "File"
     }
   tool: v1.0/dir2.cwl
-  label: directory_input_docker
-  id: 85
+  id: directory_input_docker
   doc: Test directory input in Docker
   tags: [ command_line_tool, shell_command ]
 
@@ -1180,8 +1095,7 @@
         ],
     }
   tool: v1.0/dir3.cwl
-  label: directory_output
-  id: 86
+  id: directory_output
   doc: Test directory output
   tags: [ required, command_line_tool ]
 
@@ -1195,8 +1109,7 @@
     }
   }
   tool: v1.0/dir4.cwl
-  label: directory_secondaryfiles
-  id: 87
+  id: directory_secondaryfiles
   doc: Test directories in secondaryFiles
   tags: [ shell_command, command_line_tool ]
 
@@ -1210,8 +1123,7 @@
     }
   }
   tool: v1.0/dir5.cwl
-  label: dynamic_initial_workdir
-  id: 88
+  id: dynamic_initial_workdir
   doc: Test dynamic initial work dir
   tags: [ shell_command, initial_work_dir, command_line_tool ]
 
@@ -1225,8 +1137,7 @@
     }
   }
   tool: v1.0/stagefile.cwl
-  label: writable_stagedfiles
-  id: 89
+  id: writable_stagedfiles
   doc: Test writable staged files.
   tags: [ initial_work_dir, command_line_tool ]
 
@@ -1238,8 +1149,7 @@
       location: output.txt
       size: 18
   tool: v1.0/cat3-tool.cwl
-  label: input_file_literal
-  id: 90
+  id: input_file_literal
   doc: Test file literal as input
   tags: [ required, command_line_tool ]
 
@@ -1251,8 +1161,7 @@
         class: File
         size: 0
   tool: v1.0/linkfile.cwl
-  label: initial_workdir_expr
-  id: 91
+  id: initial_workdir_expr
   doc: Test expression in InitialWorkDir listing
   tags: [ initial_work_dir, command_line_tool ]
 
@@ -1264,8 +1173,7 @@
         class: File
         size: 21
   tool: v1.0/nameroot.cwl
-  label: nameroot_nameext_stdout_expr
-  id: 92
+  id: nameroot_nameext_stdout_expr
   doc: Test nameroot/nameext expression in arguments, stdout
   tags: [ required, command_line_tool ]
 
@@ -1278,8 +1186,7 @@
         "class": "File"
     }
   tool: v1.0/dir6.cwl
-  label: input_dir_inputbinding
-  id: 93
+  id: input_dir_inputbinding
   doc: Test directory input with inputBinding
   tags: [ shell_command, command_line_tool ]
 
@@ -1291,24 +1198,21 @@
         class: File
         size: 2
   tool: v1.0/nested-array.cwl
-  label: cl_gen_arrayofarrays
-  id: 94
+  id: cl_gen_arrayofarrays
   doc: Test command line generation of array-of-arrays
   tags: [ required, command_line_tool ]
 
 - job: v1.0/empty.json
   output: {}
   tool: v1.0/envvar.cwl
-  label: env_home_tmpdir
-  id: 95
+  id: env_home_tmpdir
   doc: Test $HOME and $TMPDIR are set correctly
   tags: [ shell_command, command_line_tool ]
 
 - job: v1.0/empty.json
   output: {}
   tool: v1.0/envvar2.cwl
-  label: env_home_tmpdir_docker
-  id: 96
+  id: env_home_tmpdir_docker
   doc: Test $HOME and $TMPDIR are set correctly in Docker
   tags: [ shell_command, command_line_tool ]
 
@@ -1321,8 +1225,7 @@
         "size": 2
     }
   tool: "v1.0/js-expr-req-wf.cwl#wf"
-  label: expressionlib_tool_wf_override
-  id: 97
+  id: expressionlib_tool_wf_override
   doc: Test that expressionLib requirement of individual tool step overrides expressionLib of workflow.
   tags: [ inline_javascript, workflow ]
 
@@ -1340,16 +1243,14 @@
       "class": "File"
       "size": 12010
   tool: v1.0/initialworkdirrequirement-docker-out.cwl
-  label: initial_workdir_output
-  id: 98
+  id: initial_workdir_output
   doc: Test output of InitialWorkDir
   tags: [ docker, initial_work_dir, command_line_tool ]
 
 - job: v1.0/wc-job.json
   output: {count_output: 16}
   tool: v1.0/count-lines10-wf.cwl
-  label: embedded_subworkflow
-  id: 99
+  id: embedded_subworkflow
   doc: Test embedded subworkflow
   tags: [ subworkflow, workflow ]
 
@@ -1363,8 +1264,7 @@
     }
   }
   tool: v1.0/docker-array-secondaryfiles.cwl
-  label: filesarray_secondaryfiles
-  id: 100
+  id: filesarray_secondaryfiles
   doc: Test secondaryFiles on array of files.
   tags: [ docker, inline_javascript, shell_command, command_line_tool ]
 
@@ -1390,8 +1290,7 @@
     }
   }
   tool: v1.0/dir7.cwl
-  label: exprtool_directory_literal
-  id: 101
+  id: exprtool_directory_literal
   doc: Test directory literal output created by ExpressionTool
   tags: [ inline_javascript, expression_tool ]
 
@@ -1403,8 +1302,7 @@
       checksum: "sha1$fea23663b9c8ed71968f86415b5ec091bb111448"
       size: 19
   tool: v1.0/file-literal-ex.cwl
-  label: exprtool_file_literal
-  id: 102
+  id: exprtool_file_literal
   doc: Test file literal output created by ExpressionTool
   tags: [ inline_javascript, expression_tool ]
 
@@ -1417,8 +1315,7 @@
         "size": 0
     }
   tool: v1.0/docker-output-dir.cwl
-  label: dockeroutputdir
-  id: 103
+  id: dockeroutputdir
   doc: Test dockerOutputDirectory
   tags: [ docker, command_line_tool ]
 
@@ -1430,16 +1327,14 @@
       location: out
       size: 15
   tool: v1.0/imported-hint.cwl
-  label: hints_import
-  id: 104
+  id: hints_import
   doc: Test hints with $import
   tags: [ required, command_line_tool ]
 
 - output: {}
   job: v1.0/default_path_job.yml
   tool: v1.0/default_path.cwl
-  label: default_path_notfound_warning
-  id: 105
+  id: default_path_notfound_warning
   doc: Test warning instead of error when default path is not found
   tags: [ required, command_line_tool ]
 
@@ -1447,8 +1342,7 @@
     args: [-A,'2',-B,baz,-C,'10','9','8','7','6','5','4','3','2','1',-D]
   job: v1.0/empty.json
   tool: v1.0/inline-js.cwl
-  label: inlinejs_req_expressions
-  id: 106
+  id: inlinejs_req_expressions
   doc: Test InlineJavascriptRequirement with multiple expressions in the same tool
   tags: [ inline_javascript, command_line_tool ]
 
@@ -1503,8 +1397,7 @@
         "size": 0
       }
   tool: v1.0/recursive-input-directory.cwl
-  label: input_dir_recurs_copy_writable
-  id: 107
+  id: input_dir_recurs_copy_writable
   doc: Test if a writable input directory is recursively copied and writable
   tags: [ initial_work_dir, shell_command, command_line_tool ]
 
@@ -1512,8 +1405,7 @@
     out: "t\n"
   job: v1.0/empty.json
   tool: v1.0/null-defined.cwl
-  label: null_missing_params
-  id: 108
+  id: null_missing_params
   doc: Test that missing parameters are null (not undefined) in expression
   tags: [ inline_javascript, command_line_tool ]
 
@@ -1521,8 +1413,7 @@
     out: "f\n"
   job: v1.0/cat-job.json
   tool: v1.0/null-defined.cwl
-  label: param_notnull_expr
-  id: 109
+  id: param_notnull_expr
   doc: Test that provided parameter is not null in expression
   tags: [ inline_javascript, command_line_tool ]
 
@@ -1534,8 +1425,7 @@
       location: output.txt
       size: 1111
   tool: v1.0/revsort-packed.cwl#main
-  label: wf_compound_doc
-  id: 110
+  id: wf_compound_doc
   doc: Test compound workflow document
   tags: [ required, workflow ]
 
@@ -1554,16 +1444,14 @@
       location: Any
       path: Any
   tool: v1.0/basename-fields-test.cwl
-  label: nameroot_nameext_generated
-  id: 111
+  id: nameroot_nameext_generated
   doc: Test that nameroot and nameext are generated from basename at execution time by the runner
   tags: [ step_input, workflow ]
 
 - job: v1.0/wc-job.json
   output: {}
   tool: v1.0/initialwork-path.cwl
-  label: initialworkpath_output
-  id: 112
+  id: initialworkpath_output
   doc: Test that file path in $(inputs) for initialworkdir is in $(outdir).
   tags: [ initial_work_dir, command_line_tool ]
 
@@ -1571,8 +1459,7 @@
   output:
     count_output: 34
   tool: v1.0/count-lines12-wf.cwl
-  label: wf_scatter_twopar_oneinput_flattenedmerge
-  id: 113
+  id: wf_scatter_twopar_oneinput_flattenedmerge
   doc: >-
     Test single step workflow with Scatter step and two data links connected to
     same input, flattened merge behavior. Workflow inputs are set as list
@@ -1582,8 +1469,7 @@
   output:
     result: 12
   tool: v1.0/sum-wf.cwl
-  label: wf_multiplesources_multipletypes
-  id: 114
+  id: wf_multiplesources_multipletypes
   doc: Test step input with multiple sources with multiple types
   tags: [ step_input, inline_javascript, multiple_input, workflow ]
 
@@ -1603,8 +1489,7 @@
     }
   }
   tool: v1.0/shellchar.cwl
-  label: shelldir_notinterpreted
-  id: 115
+  id: shelldir_notinterpreted
   doc: "Test that shell directives are not interpreted."
   tags: [ required, command_line_tool ]
 
@@ -1624,8 +1509,7 @@
     }
   }
   tool: v1.0/shellchar2.cwl
-  label: shelldir_quoted
-  id: 116
+  id: shelldir_quoted
   doc: "Test that shell directives are quoted."
   tags: [ shell_command, command_line_tool ]
 
@@ -1646,8 +1530,7 @@
         "class": "Directory"
     }
   tool: v1.0/writable-dir.cwl
-  label: initial_workdir_empty_writable
-  id: 117
+  id: initial_workdir_empty_writable
   doc: Test empty writable dir with InitialWorkDirRequirement
   tags: [ inline_javascript, initial_work_dir, command_line_tool ]
 
@@ -1668,15 +1551,13 @@
         "class": "Directory"
     }
   tool: v1.0/writable-dir-docker.cwl
-  label: initial_workdir_empty_writable_docker
-  id: 118
+  id: initial_workdir_empty_writable_docker
   doc: Test empty writable dir with InitialWorkDirRequirement inside Docker
   tags: [ inline_javascript, initial_work_dir, command_line_tool ]
 
 - job: v1.0/dynresreq-job.yaml
   tool: v1.0/dynresreq.cwl
-  label: dynamic_resreq_inputs
-  id: 119
+  id: dynamic_resreq_inputs
   doc: Test dynamic resource reqs referencing inputs
   output:
      output: {
@@ -1695,15 +1576,13 @@
       location: output.txt
       size: 18
   tool: v1.0/cat3-nodocker.cwl
-  label: fileliteral_input_docker
-  id: 120
+  id: fileliteral_input_docker
   doc: Test file literal as input without Docker
   tags: [ required, command_line_tool ]
 
 - doc: Test that OutputBinding.glob is sorted as specified by POSIX
-  id: 121
   job: v1.0/empty.json
-  label: outputbinding_glob_sorted
+  id: outputbinding_glob_sorted
   tool: v1.0/glob_test.cwl
   output:
     letters:
@@ -1738,7 +1617,6 @@
   tags: [ required, command_line_tool ]
 
 - doc: Test InitialWorkDirRequirement with a nested directory structure from another step
-  id: 122
   job: v1.0/empty.json
   output:
     ya_empty:
@@ -1747,7 +1625,7 @@
       location: ya
       size: 0
   tool: v1.0/iwdr_with_nested_dirs.cwl
-  label: initialworkdir_nesteddir
+  id: initialworkdir_nesteddir
   tags: [ initial_work_dir, workflow ]
 
 - job: v1.0/bool-empty-inputbinding-job.json
@@ -1756,8 +1634,7 @@
     ]
   }
   tool: v1.0/bool-empty-inputbinding.cwl
-  label: booleanflags_cl_noinputbinding
-  id: 123
+  id: booleanflags_cl_noinputbinding
   doc: "Test that boolean flags do not appear on command line if inputBinding is empty and not null"
   tags: [ required, command_line_tool ]
 
@@ -1766,25 +1643,22 @@
     "args": []
   }
   tool: v1.0/stage-unprovided-file.cwl
-  label: expr_reference_self_noinput
-  id: 124
+  id: expr_reference_self_noinput
   doc: Test that expression engine does not fail to evaluate reference to self
        with unprovided input
   tags: [ required, command_line_tool ]
 
 - tool: v1.0/exit-success.cwl
-  label: success_codes
-  id: 125
+  id: success_codes
   doc: Test successCodes
   job: v1.0/empty.json
   output: {}
   tags: [ required, command_line_tool ]
 
 - job: v1.0/dynresreq-job.yaml
-  id: 126
   doc: Test simple workflow with a dynamic resource requirement
   tool: v1.0/dynresreq-workflow.cwl
-  label: dynamic_resreq_wf
+  id: dynamic_resreq_wf
   output:
      cores: {
         "location": "output",
@@ -1799,15 +1673,13 @@
     "args": []
   }
   tool: v1.0/empty-array-input.cwl
-  label: cl_empty_array_input
-  id: 127
+  id: cl_empty_array_input
   doc: "Test that empty array input does not add anything to command line"
   tags: [ required, command_line_tool ]
 
 - job: v1.0/empty.json
   tool: v1.0/steplevel-resreq.cwl
-  label: resreq_step_overrides_wf
-  id: 128
+  id: resreq_step_overrides_wf
   doc: Test that ResourceRequirement on a step level redefines requirement on the workflow level
   output:
      out: {
@@ -1823,15 +1695,13 @@
     "args": ["replacementValue"]
   }
   tool: v1.0/valueFrom-constant.cwl
-  label: valuefrom_constant_overrides_inputs
-  id: 129
+  id: valuefrom_constant_overrides_inputs
   doc: Test valueFrom with constant value overriding provided array inputs
   tags: [ required, command_line_tool ]
 
 - job: v1.0/dynresreq-dir-job.yaml
   tool: v1.0/dynresreq-dir.cwl
-  label: dynamic_resreq_filesizes
-  id: 130
+  id: dynamic_resreq_filesizes
   doc: Test dynamic resource reqs referencing the size of Files inside a Directory
   output:
      output: {
@@ -1844,8 +1714,7 @@
 
 - job: v1.0/empty.json
   tool: v1.0/pass-unconnected.cwl
-  label: wf_step_connect_undeclared_param
-  id: 131
+  id: wf_step_connect_undeclared_param
   doc: >-
     Test that it is not an error to connect a parameter to a workflow
     step, even if the parameter doesn't appear in the `run` process
@@ -1855,8 +1724,7 @@
 
 - job: v1.0/empty.json
   tool: v1.0/fail-unconnected.cwl
-  label: wf_step_access_undeclared_param
-  id: 132
+  id: wf_step_access_undeclared_param
   doc: >-
     Test that parameters that don't appear in the `run` process
     inputs are not present in the input object used to run the tool.
@@ -1871,8 +1739,7 @@
        checksum: "sha1$7d5ca8c0c03e883c56c4eb1ef6f6bb9bccad4d86"
        size: 8
   tool: v1.0/envvar3.cwl
-  label: env_home_tmpdir_docker_complex
-  id: 133
+  id: env_home_tmpdir_docker_complex
   doc: Test $HOME and $TMPDIR are set correctly in Docker without using return code
   tags: [ shell_command, command_line_tool ]
 
@@ -1880,8 +1747,7 @@
   output:
     out: ["foo one one", "foo one two", "foo one three", "foo one four"]
   tool: v1.0/scatter-valuefrom-inputs-wf1.cwl
-  label: wf_scatter_oneparam_valuefrom_inputs
-  id: 134
+  id: wf_scatter_oneparam_valuefrom_inputs
   doc: Test workflow scatter with single scatter parameter and two valueFrom using $inputs (first and current el)
   tags: [ scatter, step_input, workflow ]
 
@@ -1893,8 +1759,7 @@
       class: File
       size: 0
   tool: "v1.0/import_schema-def_packed.cwl#main"
-  label: packed_import_schema
-  id: 135
+  id: packed_import_schema
   doc: SchemaDefRequirement with $import, and packed
   tags: [ schema_def, workflow ]
 
@@ -1908,8 +1773,7 @@
     }
   }
   tool: v1.0/dir4.cwl
-  id: 136
-  label: job_input_secondary_subdirs
+  id: job_input_secondary_subdirs
   doc: Test specifying secondaryFiles in subdirectories of the job input document.
   tags: [ shell_command, command_line_tool ]
 
@@ -1923,8 +1787,7 @@
     }
   }
   tool: v1.0/dir4.cwl
-  id: 137
-  label: job_input_subdir_primary_and_secondary_subdirs
+  id: job_input_subdir_primary_and_secondary_subdirs
   doc: Test specifying secondaryFiles in same subdirectory of the job input as the primary input file.
   tags: [ shell_command, command_line_tool ]
 
@@ -1932,8 +1795,7 @@
   output:
     count_output: [16, 1]
   tool: v1.0/count-lines18-wf.cwl
-  id: 138
-  label: scatter_embedded_subworkflow
+  id: scatter_embedded_subworkflow
   doc: Test simple scatter over an embedded subworkflow
   tags: [ workflow, inline_javascript ]
 
@@ -1941,32 +1803,28 @@
   output:
     count_output: [16, 1]
   tool: v1.0/count-lines14-wf.cwl
-  id: 139
-  label: scatter_multi_input_embedded_subworkflow
+  id: scatter_multi_input_embedded_subworkflow
   doc: Test simple multiple input scatter over an embedded subworkflow
   tags: [ workflow, scatter, subworkflow, multiple_input, inline_javascript ]
 
 - job: v1.0/wc-job.json
   output: {count_output: 16}
   tool: v1.0/count-lines15-wf.cwl
-  id: 140
   doc: Test twice nested subworkflow
-  label: workflow_embedded_subworkflow_embedded_subsubworkflow
+  id: workflow_embedded_subworkflow_embedded_subsubworkflow
   tags: [ workflow, subworkflow, inline_javascript ]
 
 - job: v1.0/wc-job.json
   output: {count_output: 16}
   tool: v1.0/count-lines16-wf.cwl
-  id: 141
-  label: workflow_embedded_subworkflow_with_tool_and_subsubworkflow
+  id: workflow_embedded_subworkflow_with_tool_and_subsubworkflow
   doc: Test subworkflow of mixed depth with tool first
   tags: [ workflow, subworkflow, inline_javascript ]
 
 - job: v1.0/wc-job.json
   output: {count_output: 16}
   tool: v1.0/count-lines17-wf.cwl
-  id: 142
-  label: workflow_embedded_subworkflow_with_subsubworkflow_and_tool
+  id: workflow_embedded_subworkflow_with_subsubworkflow_and_tool
   doc: Test subworkflow of mixed depth with tool after
   tags: [ workflow, subworkflow, inline_javascript ]
 
@@ -1987,56 +1845,49 @@
         }
     }
   tool: v1.0/record-output-wf.cwl
-  id: 143
-  label: workflow_records_inputs_and_outputs
+  id: workflow_records_inputs_and_outputs
   doc: Test record type inputs to and outputs from workflows.
   tags: [ workflow, shell_command ]
 
 - job: v1.0/io-int.json
   output: {"o": 10}
   tool: v1.0/io-int-wf.cwl
-  id: 144
-  label: workflow_integer_input
+  id: workflow_integer_input
   doc: Test integer workflow input and outputs
   tags: [ workflow, inline_javascript, expression_tool ]
 
 - job: v1.0/io-int.json
   output: {"o": 10}
   tool: v1.0/io-int-optional-wf.cwl
-  id: 145
-  label: workflow_integer_input_optional_specified
+  id: workflow_integer_input_optional_specified
   doc: Test optional integer workflow inputs (specified)
   tags: [ workflow, inline_javascript, expression_tool ]
 
 - job: v1.0/empty.json
   output: {"o": 4}
   tool: v1.0/io-int-optional-wf.cwl
-  id: 146
-  label: workflow_integer_input_optional_unspecified
+  id: workflow_integer_input_optional_unspecified
   doc: Test optional integer workflow inputs (unspecified)
   tags: [ workflow, inline_javascript, expression_tool ]
 
 - job: v1.0/io-int.json
   output: {"o": 10}
   tool: v1.0/io-int-default-wf.cwl
-  id: 147
-  label: workflow_integer_input_default_specified
+  id: workflow_integer_input_default_specified
   doc: Test default integer workflow inputs (specified)
   tags: [ workflow, inline_javascript, expression_tool ]
 
 - job: v1.0/empty.json
   output: {"o": 8}
   tool: v1.0/io-int-default-wf.cwl
-  id: 148
-  label: workflow_integer_input_default_unspecified
+  id: workflow_integer_input_default_unspecified
   doc: Test default integer workflow inputs (unspecified)
   tags: [ workflow, inline_javascript, expression_tool ]
 
 - job: v1.0/empty.json
   output: {"o": 13}
   tool: v1.0/io-int-default-tool-and-wf.cwl
-  id: 149
-  label: workflow_integer_input_default_and_tool_integer_input_default
+  id: workflow_integer_input_default_and_tool_integer_input_default
   doc: Test default integer tool and workflow inputs (unspecified)
   tags: [ workflow, inline_javascript, expression_tool ]
 
@@ -2049,8 +1900,7 @@
             "checksum": "sha1$327fc7aedf4f6b69a42a7c8b808dc5a7aff61376"
   }}
   tool: v1.0/io-file-default-wf.cwl
-  id: 150
-  label: workflow_file_input_default_unspecified
+  id: workflow_file_input_default_unspecified
   doc: Test File input with default unspecified to workflow
   tags: [ workflow ]
 
@@ -2063,8 +1913,7 @@
                 "size": 13
   }}
   tool: v1.0/io-file-default-wf.cwl
-  id: 151
-  label: workflow_file_input_default_specified
+  id: workflow_file_input_default_specified
   doc: Test File input with default specified to workflow
   tags: [ workflow ]
 
@@ -2078,8 +1927,7 @@
         "size": 0
   }}
   tool: v1.0/io-file-or-files.cwl
-  id: 152
-  label: clt_optional_union_input_file_or_files_with_array_of_one_file_provided
+  id: clt_optional_union_input_file_or_files_with_array_of_one_file_provided
   doc: Test input union type or File or File array to a tool with one file in array specified.
   tags: [ command_line_tool, inline_javascript ]
 
@@ -2093,8 +1941,7 @@
         "size": 1114
   }}
   tool: v1.0/io-file-or-files.cwl
-  id: 153
-  label: clt_optional_union_input_file_or_files_with_many_files_provided
+  id: clt_optional_union_input_file_or_files_with_many_files_provided
   doc: Test input union type or File or File array to a tool with a few files in array specified.
   tags: [ command_line_tool, inline_javascript ]
 
@@ -2108,8 +1955,7 @@
         "size": 1111
   }}
   tool: v1.0/io-file-or-files.cwl
-  id: 154
-  label: clt_optional_union_input_file_or_files_with_single_file_provided
+  id: clt_optional_union_input_file_or_files_with_single_file_provided
   doc: Test input union type or File or File array to a tool with one file specified.
   tags: [ command_line_tool, inline_javascript ]
 
@@ -2123,136 +1969,119 @@
         "size": 10
   }}
   tool: v1.0/io-file-or-files.cwl
-  id: 155
-  label: clt_optional_union_input_file_or_files_with_nothing_provided
+  id: clt_optional_union_input_file_or_files_with_nothing_provided
   doc: Test input union type or File or File array to a tool with null specified.
   tags: [ command_line_tool, inline_javascript ]
 
 - job: v1.0/io-any-int.json
   output: {"t1": 7}
   tool: v1.0/io-any-1.cwl
-  id: 156
-  label: clt_any_input_with_integer_provided
+  id: clt_any_input_with_integer_provided
   doc: Test Any parameter with integer input to a tool
   tags: [ command_line_tool, inline_javascript ]
 
 - job: v1.0/io-any-string.json
   output: {"t1": "7"}
   tool: v1.0/io-any-1.cwl
-  id: 157
-  label: clt_any_input_with_string_provided
+  id: clt_any_input_with_string_provided
   doc: Test Any parameter with string input to a tool
   tags: [ command_line_tool, inline_javascript ]
 
 - job: v1.0/io-any-file.json
   output: {"t1": "File"}
   tool: v1.0/io-any-1.cwl
-  id: 158
-  label: clt_any_input_with_file_provided
+  id: clt_any_input_with_file_provided
   doc: Test Any parameter with file input to a tool
   tags: [ command_line_tool, inline_javascript ]
 
 - job: v1.0/io-any-array.json
   output: {"t1": [1, "moocow"]}
   tool: v1.0/io-any-1.cwl
-  id: 159
-  label: clt_any_input_with_mixed_array_provided
+  id: clt_any_input_with_mixed_array_provided
   doc: Test Any parameter with array input to a tool
   tags: [ command_line_tool, inline_javascript ]
 
 - job: v1.0/io-any-record.json
   output: {"t1": {"moo": 1, "cow": 5}}
   tool: v1.0/io-any-1.cwl
-  id: 160
-  label: clt_any_input_with_record_provided
+  id: clt_any_input_with_record_provided
   doc: Test Any parameter with record input to a tool
   tags: [ command_line_tool, inline_javascript ]
 
 - job: v1.0/io-any-int.json
   output: {"t1": 7}
   tool: v1.0/io-any-wf-1.cwl
-  id: 161
-  label: workflow_any_input_with_integer_provided
+  id: workflow_any_input_with_integer_provided
   doc: Test Any parameter with integer input to a workflow
   tags: [ workflow, inline_javascript ]
 
 - job: v1.0/io-any-string.json
   output: {"t1": "7"}
   tool: v1.0/io-any-wf-1.cwl
-  id: 162
-  label: workflow_any_input_with_string_provided
+  id: workflow_any_input_with_string_provided
   doc: Test Any parameter with string input to a workflow
   tags: [ workflow, inline_javascript ]
 
 - job: v1.0/io-any-file.json
   output: {"t1": "File"}
   tool: v1.0/io-any-wf-1.cwl
-  id: 163
-  label: workflow_any_input_with_file_provided
+  id: workflow_any_input_with_file_provided
   doc: Test Any parameter with file input to a workflow
   tags: [ workflow, inline_javascript ]
 
 - job: v1.0/io-any-array.json
   output: {"t1": [1, "moocow"]}
   tool: v1.0/io-any-wf-1.cwl
-  id: 164
-  label: workflow_any_input_with_mixed_array_provided
+  id: workflow_any_input_with_mixed_array_provided
   doc: Test Any parameter with array input to a workflow
   tags: [ workflow, inline_javascript ]
 
 - job: v1.0/io-any-record.json
   output: {"t1": {"moo": 1, "cow": 5}}
   tool: v1.0/io-any-wf-1.cwl
-  id: 165
-  label: workflow_any_input_with_record_provided
+  id: workflow_any_input_with_record_provided
   doc: Test Any parameter with record input to a tool in a workflow
   tags: [ workflow, inline_javascript ]
 
 - job: v1.0/empty.json
   output: {"o": "the default value"}
   tool: v1.0/io-union-input-default-wf.cwl
-  id: 166
-  label: workflow_union_default_input_unspecified
+  id: workflow_union_default_input_unspecified
   doc: Test union type input to workflow with default unspecified
   tags: [ workflow, inline_javascript, expression_tool ]
 
 - job: v1.0/io-any-file.json
   output: {"o": "File"}
   tool: v1.0/io-union-input-default-wf.cwl
-  id: 167
-  label: workflow_union_default_input_with_file_provided
+  id: workflow_union_default_input_with_file_provided
   doc: Test union type input to workflow with default specified as file
   tags: [ workflow, inline_javascript, expression_tool ]
 
 - job: v1.0/empty.json
   output: {"val": "moocow\n"}
   tool: v1.0/step-valuefrom4-wf.cwl
-  id: 168
-  label: workflowstep_valuefrom_string
+  id: workflowstep_valuefrom_string
   doc: Test valueFrom on workflow step from literal (string).
   tags: [ workflow, step_input ]
 
 - job: v1.0/wc-job.json
   output: {"val1": "whale.txt\n", "val2": "step1_out\n"}
   tool: v1.0/step-valuefrom5-wf.cwl
-  id: 169
-  label: workflowstep_valuefrom_file_basename
+  id: workflowstep_valuefrom_file_basename
   doc: Test valueFrom on workflow step using basename.
   tags: [ workflow, step_input ]
 
 - job: v1.0/output-arrays-int-job.json
   output: {"o": [0, 1, 2]}
   tool: v1.0/output-arrays-int.cwl
-  id: 170
-  label: expression_tool_int_array_output
+  id: expression_tool_int_array_output
   doc: Test output arrays in a tool (with ints).
   tags: [ expression_tool, inline_javascript ]
 
 - job: v1.0/output-arrays-int-job.json
   output: {"o": 12}
   tool: v1.0/output-arrays-int-wf.cwl
-  id: 171
-  label: workflowstep_int_array_input_output
+  id: workflowstep_int_array_input_output
   doc: Test output arrays in a workflow (with ints).
   tags: [ workflow, expression_tool, inline_javascript ]
 
@@ -2274,8 +2103,7 @@
     }
   ]}
   tool: v1.0/output-arrays-file-wf.cwl
-  id: 172
-  label: workflow_file_array_output
+  id: workflow_file_array_output
   doc: Test output arrays in a workflow (with Files).
   tags: [ workflow, expression_tool, inline_javascript ]
 
@@ -2289,8 +2117,7 @@
         "location": Any
   }}
   tool: "v1.0/docker-run-cmd.cwl"
-  id: 173
-  label: docker_entrypoint
+  id: docker_entrypoint
   doc: Test Docker ENTRYPOINT usage
   tags: [ command_line_tool, docker ]
 
@@ -2304,8 +2131,7 @@
         "size": 11
   }}
   tool: "v1.0/size-expression-tool.cwl"
-  id: 174
-  label: clt_file_size_property_with_empty_file
+  id: clt_file_size_property_with_empty_file
   doc: Test use of size in expressions for an empty file
   tags: [ command_line_tool, inline_javascript ]
 
@@ -2319,24 +2145,21 @@
         "size": 31
   }}
   tool: "v1.0/size-expression-tool.cwl"
-  id: 175
-  label: clt_file_size_property_with_multi_file
+  id: clt_file_size_property_with_multi_file
   doc: Test use of size in expressions for a few files
   tags: [ command_line_tool, inline_javascript ]
 
 - job: v1.0/null-expression-echo-job.json
   tool: v1.0/echo-tool.cwl
   should_fail: true
-  id: 176
-  label: any_without_defaults_unspecified_fails
+  id: any_without_defaults_unspecified_fails
   doc: Test Any without defaults, unspecified, should fail.
   tags: [ command_line_tool, required ]
 
 - job: v1.0/null-expression1-job.json
   tool: v1.0/echo-tool.cwl
   should_fail: true
-  id: 177
-  label: any_without_defaults_specified_fails
+  id: any_without_defaults_specified_fails
   doc: Test Any without defaults, specified, should fail.
   tags: [ command_line_tool, required ]
 
@@ -2347,8 +2170,7 @@
         checksum: sha1$3596ea087bfdaf52380eae441077572ed289d657
         size: 3
   tool: v1.0/count-lines9-wf-noET.cwl
-  id: 178
-  label: step_input_default_value_noexp
+  id: step_input_default_value_noexp
   doc: Test default value on step input parameter, no ExpressionTool
   tags: [ workflow, required ]
 
@@ -2359,8 +2181,7 @@
         checksum: sha1$e5fa44f2b31c1fb553b6021e7360d07d5d91ff5e
         size: 2
   tool: v1.0/count-lines11-wf-noET.cwl
-  id: 179
-  label: step_input_default_value_overriden_noexp
+  id: step_input_default_value_overriden_noexp
   doc: Test default value on step input parameter overridden by provided source, no ExpressionTool
   tags: [ workflow, required ]
 
@@ -2370,8 +2191,7 @@
         class: File
         checksum: sha1$3596ea087bfdaf52380eae441077572ed289d657
         size: 3
-  id: 180
-  label: nested_workflow_noexp
+  id: nested_workflow_noexp
   tool: v1.0/count-lines8-wf-noET.cwl
   doc: Test nested workflow, without ExpressionTool
   tags: [ workflow, subworkflow ]
@@ -2382,8 +2202,7 @@
         class: File
         checksum: sha1$ad552e6dc057d1d825bf49df79d6b98eba846ebe
         size: 3
-  id: 181
-  label: wf_multiplesources_multipletypes_noexp
+  id: wf_multiplesources_multipletypes_noexp
   tool: v1.0/sum-wf-noET.cwl
   doc: Test step input with multiple sources with multiple types, without ExpressionTool
   tags: [ workflow, step_input, inline_javascript, multiple_input ]
@@ -2396,8 +2215,7 @@
         size: 2
         class: File
         checksum: sha1$7448d8798a4380162d4b56f9b452e2f6f9e24e7a
-  id: 182
-  label: dynamic_resreq_wf_optional_file_default
+  id: dynamic_resreq_wf_optional_file_default
   doc: >-
     Within a workflow, test accessing the size attribute of an optional input
     File as part of a CommandLineTool's ResourceRequirement calculation. The
@@ -2413,8 +2231,7 @@
         size: 2
         class: File
         checksum: sha1$7448d8798a4380162d4b56f9b452e2f6f9e24e7a
-  id: 183
-  label: dynamic_resreq_wf_optional_file_step_default
+  id: dynamic_resreq_wf_optional_file_step_default
   doc: >-
     Within a workflow, test accessing the size attribute of an optional input
     File as part of a CommandLineTool's ResourceRequirement calculation. The
@@ -2424,8 +2241,7 @@
 
 - tool: v1.0/dynresreq-workflow-inputdefault.cwl
   job: v1.0/empty.json
-  id: 184
-  label: dynamic_resreq_wf_optional_file_wf_default
+  id: dynamic_resreq_wf_optional_file_wf_default
   output:
     cores:
         location: output
@@ -2440,8 +2256,7 @@
 
 - job: v1.0/cat-job.json
   output: {count_output: 1}
-  id: 185
-  label: step_input_default_value_overriden_2nd_step
+  id: step_input_default_value_overriden_2nd_step
   tool: v1.0/count-lines11-extra-step-wf.cwl
   doc: >-
     Test default value on step input parameter overridden by provided source.
@@ -2454,8 +2269,7 @@
         class: File
         checksum: sha1$e5fa44f2b31c1fb553b6021e7360d07d5d91ff5e
         size: 2
-  id: 186
-  label: step_input_default_value_overriden_2nd_step_noexp
+  id: step_input_default_value_overriden_2nd_step_noexp
   tool: v1.0/count-lines11-extra-step-wf-noET.cwl
   doc: >-
     Test default value on step input parameter overridden by provided source.
@@ -2464,8 +2278,7 @@
 
 - job: v1.0/empty.json
   output: {count_output: 16}
-  id: 187
-  label: step_input_default_value_overriden_2nd_step_null
+  id: step_input_default_value_overriden_2nd_step_null
   tool: v1.0/count-lines11-null-step-wf.cwl
   doc: >-
     Test default value on step input parameter overridden by provided source.
@@ -2478,8 +2291,7 @@
         class: File
         checksum: sha1$3596ea087bfdaf52380eae441077572ed289d657
         size: 3
-  id: 188
-  label: step_input_default_value_overriden_2nd_step_null_noexp
+  id: step_input_default_value_overriden_2nd_step_null_noexp
   tool: v1.0/count-lines11-null-step-wf-noET.cwl
   doc: >-
     Test default value on step input parameter overridden by provided source.
@@ -2493,8 +2305,7 @@
       checksum: sha1$47a013e660d408619d894b20806b1d5086aab03b
       class: File
       size: 13
-  id: 189
-  label: stdin_from_directory_literal_with_local_file
+  id: stdin_from_directory_literal_with_local_file
   doc: Pipe to stdin from user provided local File via a Directory literal
   tags: [ command_line_tool, required ]
 
@@ -2505,8 +2316,7 @@
       checksum: sha1$ef88e689559565999700d6fea7cf7ba306d04360
       class: File
       size: 26
-  id: 190
-  label: stdin_from_directory_literal_with_literal_file
+  id: stdin_from_directory_literal_with_literal_file
   doc: Pipe to stdin from literal File via a Directory literal
   tags: [ command_line_tool, required ]
 
@@ -2517,8 +2327,7 @@
       checksum: sha1$ef88e689559565999700d6fea7cf7ba306d04360
       class: File
       size: 26
-  id: 191
-  label: directory_literal_with_literal_file_nostdin
+  id: directory_literal_with_literal_file_nostdin
   doc: Test non-stdin reference to literal File via a Directory literal
   tags: [ command_line_tool, required ]
 
@@ -2530,8 +2339,7 @@
       location: output
       class: File
       size: 4
-  id: 192
-  label: no_inputs_commandlinetool
+  id: no_inputs_commandlinetool
   doc: Test CommandLineTool without inputs
   tags: [ command_line_tool, required ]
 
@@ -2539,8 +2347,7 @@
 - tool: v1.0/no-outputs-tool.cwl
   job: v1.0/cat-job.json
   output: {}
-  id: 193
-  label: no_outputs_commandlinetool
+  id: no_outputs_commandlinetool
   doc: Test CommandLineTool without outputs
   tags: [ command_line_tool, required ]
 
@@ -2552,8 +2359,7 @@
       location: output
       class: File
       size: 4
-  id: 194
-  label: no_inputs_workflow
+  id: no_inputs_workflow
   doc: Test Workflow without inputs
   tags: [ workflow, required ]
 
@@ -2561,8 +2367,7 @@
 - tool: v1.0/no-outputs-wf.cwl
   job: v1.0/cat-job.json
   output: {}
-  id: 195
-  label: no_outputs_workflow
+  id: no_outputs_workflow
   doc: Test Workflow without outputs
   tags: [ workflow, required ]
 
@@ -2573,8 +2378,7 @@
       class: File
       checksum: "sha1$2132943d72c39423e0b9425cbc40dfd5bf3e9cb2"
       size: 39
-  id: 196
-  label: anonymous_enum_in_array
+  id: anonymous_enum_in_array
   doc: Test an anonymous enum inside an array inside a record
   tags: [command_line_tool, required]
 
@@ -2585,8 +2389,7 @@
       class: File
       checksum: "sha1$f17c7d81f66e1520fca25b96b90eeeae5bbf08b0"
       size: 39
-  id: 197
-  label: schema-def_anonymous_enum_in_array
+  id: schema-def_anonymous_enum_in_array
   doc: Test an anonymous enum inside an array inside a record, SchemaDefRequirement
   tags: [command_line_tool, schema_def]
 


### PR DESCRIPTION
It moves string-based `label` fields to the `id` field for https://github.com/common-workflow-language/cwltest/issues/110.