### PR TITLE
Clarify saladVersion

### DIFF
--- a/v1.0/CommonWorkflowLanguage.yml
+++ b/v1.0/CommonWorkflowLanguage.yml
@@ -1,3 +1,4 @@
+saladVersion: v1.3
 $base: "https://w3id.org/cwl/cwl#"
 
 $namespaces:


### PR DESCRIPTION
This request clarifies `saladVersion`.
It must be `v1.3` because the schema includes union and map schemas.